### PR TITLE
[✨feat]: API Response 타입 정의

### DIFF
--- a/src/types/payload.ts
+++ b/src/types/payload.ts
@@ -1,0 +1,59 @@
+export interface SignUpPayload {
+  email: string;
+  fullName: string;
+  password: string;
+}
+
+export type SignInPayload = Omit<SignUpPayload, 'fullName'>;
+
+export interface CreateChannelPayload {
+  authRequired: boolean;
+  description: string;
+  name: string;
+}
+
+export interface CreateCommentPayload {
+  comment: string;
+  postId: string;
+}
+
+export interface SendNotificationsPayload {
+  notificationType: string;
+  notificationTypeId: string;
+  userId: string;
+  postId: string;
+}
+
+interface Pagination {
+  offset?: number;
+  limit?: number;
+}
+
+export interface GetPostByChannelPayload extends Pagination {
+  channelId: string;
+}
+
+export interface GetPostByUserPayload extends Pagination {
+  userId: string;
+}
+
+export interface UpdatePostPayload {
+  postId: string;
+  title: string;
+  image: File | null;
+  channelId: string;
+}
+
+export type CreatePostPayload = Omit<UpdatePostPayload, 'postId'>;
+
+export interface UpdateUserNamePayload {
+  fullName: string;
+  userName: string;
+}
+
+export interface GetUsersPayload extends Pagination {}
+
+export interface UpdateProfileImagePayload {
+  image: File;
+  isCover: boolean;
+}

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -1,3 +1,8 @@
+export interface UserReponse {
+  user: User;
+  token: string;
+}
+
 export interface User {
   _id: string;
   fullName: string;

--- a/src/types/responseType.ts
+++ b/src/types/responseType.ts
@@ -1,0 +1,39 @@
+export interface User {
+  _id: string;
+  fullName: string;
+  email: string;
+  posts: Post[];
+  likes: Like[];
+  comments: string[];
+  createdAt: string;
+  updatedAt: string;
+  role: string;
+  emailVerified: boolean;
+  banned: boolean;
+  isOnline: boolean;
+  followers: [];
+  following: [
+    {
+      _id: string;
+      user: string;
+      follower: string;
+      createdAt: string;
+      updatedAt: string;
+      __v: 0;
+    },
+  ];
+  notifications: Notification[];
+  messages: Message[];
+  coverImage?: string;
+  image?: string;
+}
+
+export interface Channel {
+  _id: string;
+  posts: string[];
+  name: string;
+  description: string;
+  createdAt: string;
+  updatedAt: string;
+  authRequired?: boolean;
+}

--- a/src/types/responseType.ts
+++ b/src/types/responseType.ts
@@ -67,3 +67,26 @@ export interface Comment {
   createdAt: string;
   updatedAt: string;
 }
+
+export interface Notification {
+  _id: string;
+  seen: boolean;
+  author: User;
+  user: User | string;
+  post: string | null; // post id
+  follow?: string; // user id
+  comment?: Comment;
+  message?: string; // message id
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Message {
+  _id: string;
+  message: string;
+  sender: User;
+  receiver: User;
+  seen: boolean;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/types/responseType.ts
+++ b/src/types/responseType.ts
@@ -37,3 +37,33 @@ export interface Channel {
   updatedAt: string;
   authRequired?: boolean;
 }
+
+export interface Post {
+  _id: string;
+  likes: Like[];
+  comments: Comment[];
+  channel: Channel;
+  author: User;
+  createdAt: string;
+  updatedAt: string;
+  image?: string;
+  imagePublicId?: string;
+  title: string;
+}
+
+export interface Like {
+  _id: string;
+  user: string; // user id
+  post: string; // post id
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Comment {
+  _id: string;
+  comment: string;
+  author: User;
+  post: string; // post id
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

- API 통신에 필요한 Response Type을 정의합니다.

## 🌱 구현 내용

- User
- Channel
- Post, Like, Comment
- Notification
- Message
- 해당 데이터들의 ResponseType을 response.ts에 선언해두었습니다.
- API 통신 함수의 Params type을 payload.ts에 선언해두었습니다.

## ⭐  나누고 싶은 내용

- Message는 지금 스펙에선 사용하지 않는 데이터이지만 User에 의존성이 있어서 함께 선언해두었습니다.
- 혹시 제가 놓친 부분이 있다면 말씀 부탁드려요!
