### PR TITLE
[✨feat]: AxiosInstance 생성, API 함수 작성

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.15.0",
+    "axios": "^1.6.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.1",

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,0 +1,1 @@
+export const ACCESS_TOKEN_KEY = import.meta.env.VITE_ACCESS_TOKEN_KEY;

--- a/src/services/Auth/auth.ts
+++ b/src/services/Auth/auth.ts
@@ -1,4 +1,3 @@
-import { ACCESS_TOKEN_KEY } from '@/constants/api';
 import { User } from '@/types';
 import { SignInPayload, SignUpPayload } from '@/types/payload';
 import { UserReponse } from '@/types/reponse';
@@ -14,11 +13,10 @@ export const signUp = async ({ email, fullName, password }: SignUpPayload) => {
       password,
     });
 
-    const { token } = response;
-
-    sessionStorage.setItem(ACCESS_TOKEN_KEY, token);
+    return response;
   } catch (error) {
     console.error(error);
+    return null;
   }
 };
 
@@ -29,18 +27,16 @@ export const signIn = async ({ email, password }: SignInPayload) => {
       password,
     });
 
-    const { token } = response;
-
-    sessionStorage.setItem(ACCESS_TOKEN_KEY, token);
+    return response;
   } catch (error) {
     console.error(error);
+    return null;
   }
 };
 
 export const signOut = async () => {
   try {
     await axiosAuthInstance.post(ENDPOINT.SIGNOUT);
-    sessionStorage.removeItem(ACCESS_TOKEN_KEY);
   } catch (error) {
     console.error(error);
   }
@@ -53,6 +49,7 @@ export const signOut = async () => {
 export const checkAuthUser = async () => {
   try {
     const response = await axiosAuthInstance.get<User>(ENDPOINT.AUTH_USER);
+
     return response;
   } catch (error) {
     console.error(error);

--- a/src/services/Auth/auth.ts
+++ b/src/services/Auth/auth.ts
@@ -1,0 +1,61 @@
+import { ACCESS_TOKEN_KEY } from '@/constants/api';
+import { User } from '@/types';
+import { SignInPayload, SignUpPayload } from '@/types/payload';
+import { UserReponse } from '@/types/reponse';
+
+import { axiosAuthInstance, axiosInstance } from '../axiosInstance';
+import { ENDPOINT } from '../endPoint';
+
+export const signUp = async ({ email, fullName, password }: SignUpPayload) => {
+  try {
+    const response = await axiosInstance.post<UserReponse>(ENDPOINT.SIGNUP, {
+      email,
+      fullName,
+      password,
+    });
+
+    const { token } = response;
+
+    sessionStorage.setItem(ACCESS_TOKEN_KEY, token);
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const signIn = async ({ email, password }: SignInPayload) => {
+  try {
+    const response = await axiosInstance.post<UserReponse>(ENDPOINT.SIGNIN, {
+      email,
+      password,
+    });
+
+    const { token } = response;
+
+    sessionStorage.setItem(ACCESS_TOKEN_KEY, token);
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const signOut = async () => {
+  try {
+    await axiosAuthInstance.post(ENDPOINT.SIGNOUT);
+    sessionStorage.removeItem(ACCESS_TOKEN_KEY);
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+/**
+ * @description 인증된 사용자인지 확인합니다.
+ * @return 실패할 경우 null을 반환합니다.
+ */
+export const checkAuthUser = async () => {
+  try {
+    const response = await axiosAuthInstance.get<User>(ENDPOINT.AUTH_USER);
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};

--- a/src/services/Channel/channel.ts
+++ b/src/services/Channel/channel.ts
@@ -1,0 +1,47 @@
+import { Channel } from '@/types';
+import { CreateChannelPayload } from '@/types/payload';
+
+import { axiosAuthInstance, axiosInstance } from '../axiosInstance';
+import { ENDPOINT } from '../endPoint';
+
+export const getAllChannels = async () => {
+  try {
+    const response = await axiosInstance.get<Channel[]>(ENDPOINT.CHANNELS.ALL);
+
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};
+export const getChannel = async (channelName: string) => {
+  try {
+    const response = await axiosInstance.get<Channel>(
+      ENDPOINT.CHANNELS.CHANNEL(channelName),
+    );
+
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};
+
+/**
+ * @description 채널 추가는 어드민 계정으로만 가능합니다. 포스트를 남기기 위해서 먼저 채널을 생성해야 합니다.
+ */
+export const createChannel = async ({
+  authRequired,
+  description,
+  name,
+}: CreateChannelPayload) => {
+  try {
+    await axiosAuthInstance.post(ENDPOINT.CHANNELS.CREATE, {
+      authRequired,
+      description,
+      name,
+    });
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/services/Post/comment.ts
+++ b/src/services/Post/comment.ts
@@ -1,0 +1,41 @@
+import { Comment } from '@/types';
+import { CreateCommentPayload } from '@/types/payload';
+
+import { axiosAuthInstance } from '../axiosInstance';
+import { ENDPOINT } from '../endPoint';
+
+export const createComment = async ({
+  comment,
+  postId,
+}: CreateCommentPayload) => {
+  try {
+    const response = await axiosAuthInstance.post<Comment>(
+      ENDPOINT.COMMENTS.CREATE,
+      {
+        comment,
+        postId,
+      },
+    );
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};
+
+export const deleteComment = async (commentId: string) => {
+  try {
+    const response = await axiosAuthInstance.delete<Comment>(
+      ENDPOINT.COMMENTS.DELETE,
+      {
+        data: {
+          id: commentId,
+        },
+      },
+    );
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};

--- a/src/services/Post/like.ts
+++ b/src/services/Post/like.ts
@@ -1,0 +1,41 @@
+import { Like } from '@/types';
+
+import { axiosAuthInstance } from './axiosInstance';
+import { ENDPOINT } from './endPoint';
+
+/**
+ * @description 특정 포스트에 좋아요를 눌렀을 때 호출합니다.
+ */
+export const createLike = async (postId: string) => {
+  try {
+    const response = await axiosAuthInstance.post<Like>(ENDPOINT.LIKES.CREATE, {
+      postId,
+    });
+
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};
+
+/**
+ * @description 특정 포스트에 좋아요한 것을 취소합니다.
+ */
+export const deleteLike = async (postId: string) => {
+  try {
+    const response = await axiosAuthInstance.delete<Like>(
+      ENDPOINT.LIKES.CREATE,
+      {
+        data: {
+          id: postId,
+        },
+      },
+    );
+
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};

--- a/src/services/Post/like.ts
+++ b/src/services/Post/like.ts
@@ -25,7 +25,7 @@ export const createLike = async (postId: string) => {
 export const deleteLike = async (postId: string) => {
   try {
     const response = await axiosAuthInstance.delete<Like>(
-      ENDPOINT.LIKES.CREATE,
+      ENDPOINT.LIKES.DELETE,
       {
         data: {
           id: postId,

--- a/src/services/Post/post.ts
+++ b/src/services/Post/post.ts
@@ -1,0 +1,122 @@
+import { Post } from '@/types';
+import {
+  CreatePostPayload,
+  GetPostByChannelPayload,
+  GetPostByUserPayload,
+  UpdatePostPayload,
+} from '@/types/payload';
+
+import { axiosInstance } from '../axiosInstance';
+import { ENDPOINT } from '../endPoint';
+
+export const getPostByChannel = async ({
+  channelId,
+  offset = 0,
+  limit = 10,
+}: GetPostByChannelPayload) => {
+  try {
+    const response = await axiosInstance.get<Post[]>(
+      ENDPOINT.POSTS.BY_CHANNEL_ID(channelId),
+      {
+        params: {
+          offset,
+          limit,
+        },
+      },
+    );
+
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};
+
+export const getPostByUser = async ({
+  userId,
+  offset = 0,
+  limit = 10,
+}: GetPostByUserPayload) => {
+  try {
+    const response = await axiosInstance.get<Post[]>(
+      ENDPOINT.POSTS.BY_USER_ID(userId),
+      {
+        params: {
+          offset,
+          limit,
+        },
+      },
+    );
+
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};
+
+export const createPost = async ({
+  title,
+  image,
+  channelId,
+}: CreatePostPayload) => {
+  try {
+    if (image == null) {
+      throw new Error('이미지가 비어있습니다.');
+    }
+
+    const formData = new FormData();
+    formData.append('title', title);
+    formData.append('image', image);
+    formData.append('channelId', channelId);
+
+    await axiosInstance.post(ENDPOINT.POSTS.CREATE, formData);
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const getPostDetail = async (postId: string) => {
+  try {
+    const response = await axiosInstance.get<Post>(ENDPOINT.POSTS.POST(postId));
+
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};
+
+export const updatePost = async ({
+  postId,
+  title,
+  image,
+  channelId,
+}: UpdatePostPayload) => {
+  try {
+    const formData = new FormData();
+    formData.append('postId', postId);
+    formData.append('title', title);
+    formData.append('channelId', channelId);
+
+    if (image instanceof File) {
+      formData.append('image', image);
+    }
+
+    await axiosInstance.put<Post>(ENDPOINT.POSTS.UPDATE, formData);
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const deletePost = async (postId: string) => {
+  try {
+    await axiosInstance.delete(ENDPOINT.POSTS.DELETE, {
+      data: {
+        id: postId,
+      },
+    });
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/services/Search/search.ts
+++ b/src/services/Search/search.ts
@@ -1,0 +1,30 @@
+import { Post, User } from '@/types';
+
+import { axiosInstance } from '../axiosInstance';
+import { ENDPOINT } from '../endPoint';
+
+export const searchUsers = async (query: string) => {
+  try {
+    const response = await axiosInstance.get<User[]>(
+      ENDPOINT.SEARCH.USERS(query),
+    );
+
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};
+
+export const searchAll = async (query: string) => {
+  try {
+    const response = await axiosInstance.get<User[] | Post[]>(
+      ENDPOINT.SEARCH.ALL(query),
+    );
+
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};

--- a/src/services/User/notification.ts
+++ b/src/services/User/notification.ts
@@ -1,0 +1,58 @@
+import { Notification } from '@/types';
+import { SendNotificationsPayload } from '@/types/payload';
+
+import { axiosAuthInstance } from '../axiosInstance';
+import { ENDPOINT } from '../endPoint';
+
+export const getNotifications = async () => {
+  try {
+    const response = await axiosAuthInstance.delete<Notification>(
+      ENDPOINT.NOTIFICATIONS.ALL,
+    );
+
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};
+
+export const seenNotifications = async () => {
+  try {
+    await axiosAuthInstance.put(ENDPOINT.NOTIFICATIONS.SEEN);
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+/**
+ * @description 상대방에게 알림을 보냅니다.
+ * @param notificationType 'COMMENT' | 'FOLLOW' | 'LIKE' | 'MESSAGE'
+ * @param notificationTypeId type에 해당하는 객체의 id를 넣어주세요.
+ * ex) COMMENT: 댓글 id | FOLLOW: 팔로우 id | LIKE: 좋아요 id | MESSAGE: 메시지 id
+ * @exception type이 FOLLOW일 경우엔 postId는 null로 보내주세요.
+ */
+
+export const sendNotifications = async ({
+  notificationType,
+  notificationTypeId,
+  userId,
+  postId,
+}: SendNotificationsPayload) => {
+  try {
+    const response = await axiosAuthInstance.post<Notification>(
+      ENDPOINT.NOTIFICATIONS.CREATE,
+      {
+        notificationType,
+        notificationTypeId,
+        userId,
+        postId,
+      },
+    );
+
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};

--- a/src/services/User/setting.ts
+++ b/src/services/User/setting.ts
@@ -1,0 +1,35 @@
+import { User } from '@/types';
+import { UpdateUserNamePayload } from '@/types/payload';
+
+import { axiosAuthInstance } from '../axiosInstance';
+import { ENDPOINT } from '../endPoint';
+
+export const updateUserName = async ({
+  fullName,
+  userName,
+}: UpdateUserNamePayload) => {
+  try {
+    const response = await axiosAuthInstance.put<User>(
+      ENDPOINT.SETTINGS.UPDATE_USER,
+      {
+        fullName,
+        userName,
+      },
+    );
+
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};
+
+export const updateUserPassword = async (password: string) => {
+  try {
+    await axiosAuthInstance.put(ENDPOINT.SETTINGS.UPDATE_PASSWORD, {
+      password,
+    });
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/services/User/user.ts
+++ b/src/services/User/user.ts
@@ -1,0 +1,53 @@
+import { User } from '@/types';
+import { GetUsersPayload, UpdateProfileImagePayload } from '@/types/payload';
+
+import { axiosInstance } from '../axiosInstance';
+import { ENDPOINT } from '../endPoint';
+
+export const getUsers = async ({ offset = 0, limit = 10 }: GetUsersPayload) => {
+  try {
+    const response = await axiosInstance.get<User[]>(ENDPOINT.USERS.GET_USERS, {
+      params: {
+        offset,
+        limit,
+      },
+    });
+
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};
+
+export const getUser = async (userId: string) => {
+  try {
+    const response = await axiosInstance.get<User>(ENDPOINT.USERS.USER(userId));
+
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};
+
+export const updateProfileImage = async ({
+  image,
+  isCover = false,
+}: UpdateProfileImagePayload) => {
+  try {
+    const formData = new FormData();
+    formData.append('isCover', isCover ? 'true' : 'false');
+    formData.append('image', image);
+
+    const response = await axiosInstance.post<User>(
+      ENDPOINT.USERS.UPLOAD_PHOTO,
+      formData,
+    );
+
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};

--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -1,0 +1,39 @@
+import axios, {
+  AxiosError,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from 'axios';
+
+import { ACCESS_TOKEN_KEY } from '@/constants/api';
+import { CustomInstance } from '@/types/api';
+
+const axiosConfig = {
+  baseURL: import.meta.env.VITE_BASE_URL,
+};
+
+export const axiosInstance: CustomInstance = axios.create(axiosConfig);
+export const axiosAuthInstance: CustomInstance = axios.create(axiosConfig);
+
+const onResponse = (response: AxiosResponse): AxiosResponse => {
+  return response.data;
+};
+
+const onError = (error: AxiosError) => {
+  console.error(error);
+  return Promise.reject(error);
+};
+
+axiosInstance.interceptors.response.use(onResponse, onError);
+axiosAuthInstance.interceptors.response.use(onResponse, onError);
+
+const onRequest = (config: InternalAxiosRequestConfig) => {
+  const accessToken = sessionStorage.getItem(ACCESS_TOKEN_KEY);
+
+  if (accessToken) {
+    config.headers.Authorization = `Bearer ${accessToken}`;
+  }
+
+  return config;
+};
+
+axiosAuthInstance.interceptors.request.use(onRequest, onError);

--- a/src/services/endPoint.ts
+++ b/src/services/endPoint.ts
@@ -1,0 +1,59 @@
+export const ENDPOINT = {
+  /* auth */
+  SIGNIN: '/login',
+  SIGNUP: '/signUp',
+  SIGNOUT: '/logout',
+  AUTH_USER: '/auth-user',
+
+  /* channel */
+  CHANNELS: {
+    ALL: '/channels',
+    CHANNEL: (channelName: string) => `/channels/${channelName}`,
+    CREATE: '/channels/create',
+  },
+
+  /* posts */
+  POSTS: {
+    CREATE: '/posts/create',
+    UPDATE: '/posts/update',
+    DELETE: '/posts/delete',
+    POST: (postId: string) => `/posts/${postId}`,
+    BY_CHANNEL_ID: (channelId: string) => `/posts/channel/${channelId}`,
+    BY_USER_ID: (userId: string) => `/posts/author/${userId}`,
+  },
+
+  LIKES: {
+    CREATE: '/likes/create',
+    DELETE: '/likes/delete',
+  },
+
+  COMMENTS: {
+    CREATE: '/comments/create',
+    DELETE: '/comments/delete',
+  },
+
+  /* user */
+  USERS: {
+    GET_USERS: '/users/get-users',
+    USER: (userId: string) => `/users/${userId}`,
+    UPLOAD_PHOTO: '/users/upload-photo',
+  },
+
+  SETTINGS: {
+    UPDATE_USER: '/settings/update-user',
+    UPDATE_PASSWORD: '/settings/update-password',
+  },
+
+  /* search */
+  SEARCH: {
+    USERS: (query: string) => `/search/users/${query}`,
+    ALL: (query: string) => `/search/all/${query}`,
+  },
+
+  /* notification */
+  NOTIFICATIONS: {
+    ALL: '/notifications',
+    SEEN: '/notifications/seen',
+    CREATE: '/notifications/create',
+  },
+};

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,12 @@
+import { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+export interface CustomInstance extends AxiosInstance {
+  get<T>(url: string, config?: AxiosRequestConfig): Promise<T>;
+  post<T>(url: string, data?: unknown, config?: AxiosRequestConfig): Promise<T>;
+  delete<T>(url: string, confg?: AxiosRequestConfig): Promise<T>;
+}
+
+export type CustomResponseFormat<T = unknown> = {
+  status: number;
+  data?: T;
+};

--- a/src/types/payload.ts
+++ b/src/types/payload.ts
@@ -1,0 +1,59 @@
+export interface SignUpPayload {
+  email: string;
+  fullName: string;
+  password: string;
+}
+
+export type SignInPayload = Omit<SignUpPayload, 'fullName'>;
+
+export interface CreateChannelPayload {
+  authRequired: boolean;
+  description: string;
+  name: string;
+}
+
+export interface CreateCommentPayload {
+  comment: string;
+  postId: string;
+}
+
+export interface SendNotificationsPayload {
+  notificationType: string;
+  notificationTypeId: string;
+  userId: string;
+  postId: string;
+}
+
+interface Pagination {
+  offset?: number;
+  limit?: number;
+}
+
+export interface GetPostByChannelPayload extends Pagination {
+  channelId: string;
+}
+
+export interface GetPostByUserPayload extends Pagination {
+  userId: string;
+}
+
+export interface UpdatePostPayload {
+  postId: string;
+  title: string;
+  image: File | null;
+  channelId: string;
+}
+
+export type CreatePostPayload = Omit<UpdatePostPayload, 'postId'>;
+
+export interface UpdateUserNamePayload {
+  fullName: string;
+  userName: string;
+}
+
+export interface GetUsersPayload extends Pagination {}
+
+export interface UpdateProfileImagePayload {
+  image: File;
+  isCover: boolean;
+}

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -1,0 +1,97 @@
+export interface UserReponse {
+  user: User;
+  token: string;
+}
+
+export interface User {
+  _id: string;
+  fullName: string;
+  email: string;
+  posts: Post[];
+  likes: Like[];
+  comments: string[];
+  createdAt: string;
+  updatedAt: string;
+  role: string;
+  emailVerified: boolean;
+  banned: boolean;
+  isOnline: boolean;
+  followers: [];
+  following: [
+    {
+      _id: string;
+      user: string;
+      follower: string;
+      createdAt: string;
+      updatedAt: string;
+      __v: 0;
+    },
+  ];
+  notifications: Notification[];
+  messages: Message[];
+  coverImage?: string;
+  image?: string;
+}
+
+export interface Channel {
+  _id: string;
+  posts: string[];
+  name: string;
+  description: string;
+  createdAt: string;
+  updatedAt: string;
+  authRequired?: boolean;
+}
+
+export interface Post {
+  _id: string;
+  likes: Like[];
+  comments: Comment[];
+  channel: Channel;
+  author: User;
+  createdAt: string;
+  updatedAt: string;
+  image?: string;
+  imagePublicId?: string;
+  title: string;
+}
+
+export interface Like {
+  _id: string;
+  user: string; // user id
+  post: string; // post id
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Comment {
+  _id: string;
+  comment: string;
+  author: User;
+  post: string; // post id
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Notification {
+  _id: string;
+  seen: boolean;
+  author: User;
+  user: User | string;
+  post: string | null; // post id
+  follow?: string; // user id
+  comment?: Comment;
+  message?: string; // message id
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Message {
+  _id: string;
+  message: string;
+  sender: User;
+  receiver: User;
+  seen: boolean;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -992,6 +992,11 @@ asynciterator.prototype@^1.0.0:
   dependencies:
     has-symbols "^1.0.3"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 autoprefixer@^10.4.16:
   version "10.4.16"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.16.tgz#fad1411024d8670880bdece3970aa72e3572feb8"
@@ -1008,6 +1013,15 @@ available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
+
+axios@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.3.tgz#7f50f23b3aa246eff43c54834272346c396613f4"
+  integrity sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-plugin-macros@^3.1.0:
   version "3.1.0"
@@ -1165,6 +1179,13 @@ colorette@^2.0.20:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
@@ -1249,6 +1270,11 @@ define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 didyoumean@^1.2.2:
   version "1.2.2"
@@ -1698,6 +1724,11 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
+follow-redirects@^1.15.0:
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
+  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -1712,6 +1743,15 @@ foreground-child@^3.1.0:
   dependencies:
     cross-spawn "^7.0.0"
     signal-exit "^4.0.1"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fraction.js@^4.3.6:
   version "4.3.7"
@@ -2379,6 +2419,18 @@ micromatch@4.0.5, micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -2724,6 +2776,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.1"


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

- BaseURL, Error 등을 한 번에 관리하기 위해 AxiosInstance를 만들고 재사용합니다.
- **`AxiosAuthInstance`**
    - 인증이 필요한 요청의 경우 interceptor를 이용하여 header에 token을 추가하여 요청합니다.
- **`AxiosInstance`**
    - 인증이 필요하지 않은 경우 사용합니다.
- 관심사별로 폴더를 생성하여 비동기 API 함수를 추가하였습니다.

## 🌱 구현 내용

- [x] EndPoint, AccesToken key값 상수화
- [x] 인증과 관련된 BaseURL, AccessToken key 값은 env 파일에서 관리
- [x] AxiosInstance 추가
- [x] 관심사별 API 함수 추가

## 🌱 나누고 싶은 점

- API base url과 token의 key값은 인증과 관련된 부분이라 env 파일에서 관리하는게 좋을 것 같습니다! **`실행하려면 env 파일이 필요`** 할 것 같아서 슬랙에 남겨두겠습니다.
- 인증 필요 유무에 따라서 **2개의 AxiosInstance를 사용**합니다.
- API 함수를 관심사별로 폴더에 나눠봤는데 괜찮은지 검토 부탁드립니다. 그리고 혹시 제가 놓친 부분이 있다면 말씀 부탁드려요!