### PR TITLE
[✨feat]: Badge 공통 컴포넌트 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,7 +54,7 @@ const router = createBrowserRouter([
 function App() {
   return (
     <>
-      <RouterProvider router={router} />;
+      <RouterProvider router={router} />
       <Global styles={reset} />
     </>
   );

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled';
+import { PropsWithChildren } from 'react';
+
+interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: 'outline' | 'solid' | 'subtle';
+}
+
+const variantStyles = {
+  outline: `
+    background-color: white;
+    color: gray;
+    border: 1px solid #e4e4e7; // gray-200에 해당하는 색상
+  `,
+  solid: `
+    background-color: white;
+    color: #a1a1aa; // gray-500에 해당하는 색상
+  `,
+  subtle: `
+    background-color: #fafafa; // active-lightest에 해당하는 색상
+    color: #5a67d8; // active-darken에 해당하는 색상
+  `,
+};
+
+const BadgeComponent = styled.span<BadgeProps>`
+  ${({ variant }) => variantStyles[variant || 'outline']}
+  display: inline-block;
+  min-height: 1rem;
+  border-radius: 15px;
+  padding: 0.25rem 0.5rem;
+  width: fit-content;
+  font-size: 0.625rem;
+`;
+
+export const Badge = ({
+  variant = 'outline',
+  children,
+  ...props
+}: PropsWithChildren<BadgeProps>) => {
+  return (
+    <BadgeComponent variant={variant} {...props}>
+      {children}
+    </BadgeComponent>
+  );
+};

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -7,17 +7,16 @@ interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
 
 const variantStyles = {
   outline: `
-    background-color: white;
-    color: gray;
-    border: 1px solid #e4e4e7; // gray-200에 해당하는 색상
+    background-color: #FFF7F5;
+    color: #black;
   `,
   solid: `
     background-color: white;
     color: #a1a1aa; // gray-500에 해당하는 색상
   `,
   subtle: `
-    background-color: #fafafa; // active-lightest에 해당하는 색상
-    color: #5a67d8; // active-darken에 해당하는 색상
+    background-color: #FFA614;
+    color: #black;
   `,
 };
 

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -20,6 +20,12 @@ const variantStyles = {
   `,
 };
 
+/**
+ * @summary <Badge variant="outline">outline</Badge>
+ * @param {string} variant - outline, solid, subtle
+ * @param {React.ReactNode} children - Badge 내부에 들어갈 내용
+ */
+
 const BadgeComponent = styled.span<BadgeProps>`
   ${({ variant }) => variantStyles[variant || 'outline']}
   display: inline-block;

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -37,7 +37,7 @@ const BadgeComponent = styled.span<BadgeProps>`
 `;
 
 export const Badge = ({
-  variant = 'outline',
+  variant,
   children,
   ...props
 }: PropsWithChildren<BadgeProps>) => {


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

- 메인 페이지, 리뷰 등록 페이지 등에 쓰일 Badge 컴포넌트 구현했습니다.

## 🌱 구현 내용

![Badge컴포넌트](https://github.com/prgrms-fe-devcourse/FEDC5_MatNam_Ducki/assets/44563138/18422162-dd75-4567-ae9f-0e26f8482d51)
- variant 변수를 주어 badge를 선택할 수 있습니다. outline이 default 값입니다.

## 🌱 나누고자 하는 내용

- subtle variant는 채널이 선택된 경우 강조할 때 사용하려고 구현했습니다
- 혹시 badge에 추가하고 싶으신 스타일링 있으시면 말씀해주세요!
