### PR TITLE
[✨feat]: Recoil 초기 설정, localStorageEffect 추가 

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { RecoilRoot } from 'recoil';
 
 import App from './App.tsx';
 import { theme } from './styles/Theme.ts';
@@ -19,8 +20,10 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
       <QueryClientProvider client={queryClient}>
-        <App />
-        <ReactQueryDevtools initialIsOpen={false} />
+        <RecoilRoot>
+          <App />
+          <ReactQueryDevtools initialIsOpen={false} />
+        </RecoilRoot>
       </QueryClientProvider>
     </ThemeProvider>
   </React.StrictMode>,

--- a/src/recoil/localStorage.ts
+++ b/src/recoil/localStorage.ts
@@ -1,0 +1,19 @@
+import { AtomEffect, DefaultValue } from 'recoil';
+
+export const localStorageEffect =
+  <T>(key: string): AtomEffect<T> =>
+  ({ setSelf, onSet }) => {
+    const savedValue = localStorage.getItem(key);
+
+    if (savedValue !== null) {
+      setSelf(JSON.parse(savedValue));
+    }
+
+    onSet((newValue: T, _: T | DefaultValue, isReset: boolean) => {
+      if (isReset) {
+        localStorage.removeItem(key);
+      } else {
+        localStorage.setItem(key, JSON.stringify(newValue));
+      }
+    });
+  };


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

전역 상태를 관리하는 Recoil 사용을 위해 초기 세팅을 합니다.

## 🌱 구현 내용

- Recoil Root 설정
- 폴더명을 atoms에서 recoil로 변경
- LocalStorage에 전역 상태 atom 값을 저장하는 기능인 localStorageEffect 추가

## ✅ 나누고 싶은 점

- 모달을 구현하다가 **모달의 상태는 전역으로 관리하고 필요한 곳에서만 호출**해서 사용할 수 있도록 하는 것이 유지보수하기 좋을 것 같다고 생각돼서
- Recoil 세팅을 먼저 진행하게 되었습니다!
- 멘토님 코멘트를 참고해서 **`폴더명을 atoms에서 recoil로 변경`** 했습니다.
- localStorageEffect는 **`전역 상태 atom을 localStorage에 저장`** 할 수 있게 해주는 역할을 합니다.
- 변경된 부분이 적어서 merge 해주시믄 모달 작업도 이어서 빠르게 작업해보도록 하겠습니다~!

###  localStorageEffect 사용법
```ts
export const modalAtom = atom<ModalStateType[]>({
  key: 'modalState',
  default: [],
  // 요 부분만 추가해주심 됩니다!
  effects: [localStorageEffect<ModalStateType[]>(로컬스토리지_키값)],
});
```
