### PR TITLE
[✨feat]: 인증 API 사용을 위한 테스트 계정 로그인 버튼 추가

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { ACCESS_TOKEN_KEY } from '@/constants/api';
-import { signIn, signUp } from '@/services/Auth/auth';
+import { signIn, signOut, signUp } from '@/services/Auth/auth';
 
 interface AuthProps {
   onSuccess?: () => void;
@@ -40,6 +40,23 @@ export const useSignIn = ({ onSuccess }: AuthProps = {}) => {
         if (onSuccess) {
           onSuccess();
         }
+      }
+    },
+  });
+};
+
+/**
+ * @description useMutation으로 로그아웃 API를 호출하는 hook입니다. 성공 시 access token을 로컬 스토리지에서 삭제합니다.
+ * @param onSuccess - optional) 성공 시 수행할 callback 함수를 넘겨줄 때 사용합니다.
+ */
+export const useSignOut = ({ onSuccess }: AuthProps = {}) => {
+  return useMutation({
+    mutationFn: signOut,
+    onSuccess: () => {
+      localStorage.removeItem(ACCESS_TOKEN_KEY);
+
+      if (onSuccess) {
+        onSuccess();
       }
     },
   });

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,11 +1,15 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { ACCESS_TOKEN_KEY } from '@/constants/api';
-import { signIn, signOut, signUp } from '@/services/Auth/auth';
+import { checkAuthUser, signIn, signOut, signUp } from '@/services/Auth/auth';
 
 interface AuthProps {
   onSuccess?: () => void;
 }
+
+const authKeys = {
+  checkAuthUser: ['checkAuthUser'] as const,
+};
 
 /**
  * @description useMutation으로 회원가입 API를 호출하는 hook입니다. 성공 시 access token을 로컬 스토리지에 저장합니다.
@@ -55,6 +59,23 @@ export const useSignOut = ({ onSuccess }: AuthProps = {}) => {
     onSuccess: () => {
       localStorage.removeItem(ACCESS_TOKEN_KEY);
 
+      if (onSuccess) {
+        onSuccess();
+      }
+    },
+  });
+};
+
+/**
+ * @description useQuery로 checkAuthUser API를 호출하는 hook입니다. 인증된 사용자인지 확인합니다.
+ * @param onSuccess - optional) 성공 시 수행할 callback 함수를 넘겨줄 때 사용합니다.
+ * @return 성공 시 User, 실패 시 null을 반환합니다.
+ */
+export const useCheckAuthUser = ({ onSuccess }: AuthProps = {}) => {
+  return useQuery({
+    queryKey: authKeys.checkAuthUser,
+    queryFn: checkAuthUser,
+    onSuccess: () => {
       if (onSuccess) {
         onSuccess();
       }

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,3 +1,47 @@
+import styled from '@emotion/styled';
+
+import { useSignIn, useSignOut } from '@/hooks/useAuth';
+
 export default function MainPage() {
-  return <div>main</div>;
+  const testUser = {
+    email: 'test@gmail.com',
+    password: 'aaaaaaaa!',
+  };
+
+  const { mutate: signIn } = useSignIn({
+    onSuccess: () => alert('test@gmail.com 로그인 완료!'),
+  });
+  const { mutate: signOut } = useSignOut({
+    onSuccess: () => alert('test@gmail.com 로그아웃 완료!'),
+  });
+
+  const handleSignIn = () => {
+    signIn(testUser);
+  };
+
+  const handleSignOut = () => {
+    signOut();
+  };
+
+  const MainPageWrapper = styled.div`
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 2rem;
+  `;
+
+  const TestButton = styled.button`
+    border: 1px solid black;
+    padding: 0.5rem;
+    border-radius: 0.3rem;
+  `;
+
+  return (
+    <MainPageWrapper>
+      <TestButton onClick={handleSignIn}>테스트 계정 로그인</TestButton>
+      <TestButton onClick={handleSignOut}>테스트 계정 로그아웃</TestButton>
+    </MainPageWrapper>
+  );
 }

--- a/src/services/axiosInstance.ts
+++ b/src/services/axiosInstance.ts
@@ -34,7 +34,7 @@ axiosInstance.interceptors.response.use(onResponse, onError);
 axiosAuthInstance.interceptors.response.use(onResponse, onError);
 
 const onRequest = (config: InternalAxiosRequestConfig) => {
-  const accessToken = sessionStorage.getItem(ACCESS_TOKEN_KEY);
+  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
 
   if (accessToken) {
     config.headers.Authorization = `Bearer ${accessToken}`;


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

로그인 후에 사용이 가능한 API들이 많아서
테스트하기 편한 환경을 만들기 위해 메인 페이지에 테스트 계정 로그인, 로그아웃 버튼을 추가합니다.

## 🌱 구현 내용

- logout, checkAuthUser API를 useAuth hook에 추가
- axiosInstance의 **`token 저장소를 localStorage로 변경`**
- 테스트 계정 로그인, 로그아웃 버튼 추가
- API 호출 성공 시에 alert 창이 뜨게 됩니다.
  - 로그인: token을 로컬 스토리지에 저장
  - 로그아웃: 로컬 스토리지에 저장된 token 제거

## ✅ 나누고 싶은 점

- test@gmail.com이라는 아이디를 공용 테스트 계정으로 사용해보면 좋을 것 같습니다!
- MainPage를 폴더 구조로 바꾸게 되면 충돌이 날 수도 있을 것 같아서 일단은 styled 컴포넌트들도 한 파일에 선언했습니다.
- 혹시 제가 놓친 부분이 있다면 말씀 부탁드려요!