### PR TITLE
[🎨style]: 루트 폰트 크기 설정

### DIFF
--- a/src/styles/Global.ts
+++ b/src/styles/Global.ts
@@ -96,6 +96,11 @@ export const reset = css`
     font: inherit;
     vertical-align: baseline;
   }
+
+  body {
+    font-size: 1.6rem;
+  }
+
   /* HTML5 display-role reset for older browsers */
   article,
   aside,

--- a/src/styles/Global.ts
+++ b/src/styles/Global.ts
@@ -5,8 +5,10 @@ export const reset = css`
    v2.0 | 20110126
    License: none (public domain)
 */
+  html {
+    font-size: 62.5%;
+  }
 
-  html,
   body,
   div,
   span,


### PR DESCRIPTION
## 🌱 만들고자 하는 기능
루트 폰트 크기가 16px로 지정되어 있어서 rem을 사용할 때 소수점을 마주하는 문제가 있습니다.
계산하기 편하도록 루트 폰트 크기를 10px로 지정합니다.

## 🌱 구현 내용

- html의 font-size를 62.5%로 지정 (=16px * 0.625 = 10px)
- body의 font-size를 1.6rem으로 지정 (16px)

## ✅ 나누고 싶은 점

- 저희 rem을 사용할 때 소수점이 점점 길어지는 것 같아서.. 😂 찾아보니 루트 폰트 크기를 10px로 지정해서 많이 사용하는 것 같더라구요
- 이렇게 하면 **`1rem이 10px`** 이 되어서 계산하기 더 편해질 것 같아요~! [관련 블로그 글](https://velog.io/@qhflrnfl4324/html-font-size-62.5-%EB%A5%BC-%EC%A0%81%EC%9A%A9%ED%95%98%EC%9E%90)
- 하지만 이렇게 적용해보니 작아진 느낌이 드는 UI들이 있어서 **10px에 맞춰서 rem들을 조정해주는게 필요할 것 같습니다!**
- body 폰트 사이즈를 1.6rem으로 설정해서 기존과 폰트 크기는 같은데 padding이나 width등이 달라졌을 거예요!