### PR TITLE
[✨feat]: 검색창 및 API 연동 구현

### DIFF
--- a/src/components/Common/HookFormInput.tsx
+++ b/src/components/Common/HookFormInput.tsx
@@ -4,15 +4,19 @@ import { FieldValues } from 'react-hook-form';
 import { HookFormInputProps } from '@/types/input';
 
 const InputWrapper = styled.div`
+  width: 100%;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 1rem;
+  position: relative;
 `;
 
 const Input = styled.input`
+  width: 100%;
   border: 1px solid #dadada;
-  border-radius: 4px;
-  padding: 2px 4px;
+  border-radius: 1rem;
+  padding: 0.2rem 0.4rem;
+  outline: none;
 `;
 
 /**
@@ -49,7 +53,7 @@ export default function HookFormInput<T extends FieldValues>({
           ...validation,
           required: required && '값을 입력해 주세요.',
         })}
-        autoComplete="true"
+        autoComplete="off"
         {...props}
       />
       {inputError && <span>{inputError.message as string}</span>}

--- a/src/components/Common/Icons/CloseFilledIcon.tsx
+++ b/src/components/Common/Icons/CloseFilledIcon.tsx
@@ -1,6 +1,4 @@
-interface CloseFilledIconProps extends React.ComponentProps<'svg'> {}
-
-export default function CloseFilledIcon(props: CloseFilledIconProps) {
+export default function CloseFilledIcon(props: React.ComponentProps<'svg'>) {
   return (
     <svg
       width="16"

--- a/src/components/Common/Icons/CloseFilledIcon.tsx
+++ b/src/components/Common/Icons/CloseFilledIcon.tsx
@@ -1,0 +1,26 @@
+interface CloseFilledIconProps extends React.ComponentProps<'svg'> {}
+
+export default function CloseFilledIcon(props: CloseFilledIconProps) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M8 16C12.4183 16 16 12.4183 16 8C16 3.58172 12.4183 0 8 0C3.58172 0 0 3.58172 0 8C0 12.4183 3.58172 16 8 16Z"
+        fill="#D8D8D8"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M5.87868 5.17157C5.68342 4.9763 5.36684 4.9763 5.17157 5.17157C4.97631 5.36683 4.97631 5.68341 5.17157 5.87867L7.2929 8L5.17158 10.1213C4.97631 10.3166 4.97632 10.6332 5.17158 10.8284C5.36684 11.0237 5.68342 11.0237 5.87868 10.8284L8.00001 8.70711L10.1213 10.8284C10.3166 11.0237 10.6332 11.0237 10.8284 10.8284C11.0237 10.6332 11.0237 10.3166 10.8284 10.1213L8.70712 8L10.8284 5.87869C11.0237 5.68343 11.0237 5.36685 10.8284 5.17158C10.6332 4.97632 10.3166 4.97632 10.1213 5.17158L8.00001 7.2929L5.87868 5.17157Z"
+        fill="#010F07"
+      />
+    </svg>
+  );
+}

--- a/src/components/Common/Icons/CloseIcon.tsx
+++ b/src/components/Common/Icons/CloseIcon.tsx
@@ -1,6 +1,4 @@
-interface CloseIconProps extends React.ComponentProps<'svg'> {}
-
-export default function CloseIcon(props: CloseIconProps) {
+export default function CloseIcon(props: React.ComponentProps<'svg'>) {
   return (
     <svg
       focusable="false"

--- a/src/components/Common/Icons/CloseIcon.tsx
+++ b/src/components/Common/Icons/CloseIcon.tsx
@@ -1,11 +1,15 @@
-export default function CloseIcon() {
+interface CloseIconProps extends React.ComponentProps<'svg'> {}
+
+export default function CloseIcon(props: CloseIconProps) {
   return (
     <svg
+      focusable="false"
       xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 50 50"
+      viewBox="0 0 24 24"
       width="15"
-      height="15">
-      <path d="M 9.15625 6.3125 L 6.3125 9.15625 L 22.15625 25 L 6.21875 40.96875 L 9.03125 43.78125 L 25 27.84375 L 40.9375 43.78125 L 43.78125 40.9375 L 27.84375 25 L 43.6875 9.15625 L 40.84375 6.3125 L 25 22.15625 Z" />
+      height="15"
+      {...props}>
+      <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
     </svg>
   );
 }

--- a/src/components/Common/Icons/SearchIcon.tsx
+++ b/src/components/Common/Icons/SearchIcon.tsx
@@ -1,6 +1,4 @@
-interface SearchIconProps extends React.ComponentProps<'svg'> {}
-
-export default function SearchIcon(props: SearchIconProps) {
+export default function SearchIcon(props: React.ComponentProps<'svg'>) {
   return (
     <svg
       focusable="false"

--- a/src/components/Common/Icons/SearchIcon.tsx
+++ b/src/components/Common/Icons/SearchIcon.tsx
@@ -1,0 +1,15 @@
+interface SearchIconProps extends React.ComponentProps<'svg'> {}
+
+export default function SearchIcon(props: SearchIconProps) {
+  return (
+    <svg
+      focusable="false"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width="20"
+      height="20"
+      {...props}>
+      <path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>
+    </svg>
+  );
+}

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -1,0 +1,75 @@
+import { css } from '@emotion/react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+
+import { useSearchAll } from '@/hooks/useSearch';
+import { SearchResultType } from '@/types/response';
+
+import HookFormInput from '../Common/HookFormInput';
+import CloseFilledIcon from '../Common/Icons/CloseFilledIcon';
+import SearchIcon from '../Common/Icons/SearchIcon';
+import { SearchButton, SearchCloseButton, SearchForm } from './style';
+
+interface SearchBarValues {
+  search: string;
+}
+
+interface SearchBarProps {
+  onSearchResult?: (result: SearchResultType) => void;
+}
+
+export default function SearchBar({ onSearchResult }: SearchBarProps) {
+  const { register, handleSubmit, watch, setFocus, resetField, setValue } =
+    useForm<SearchBarValues>();
+
+  const searchValue = watch('search');
+
+  const { refetch } = useSearchAll(searchValue);
+
+  const handleResetValue = () => {
+    resetField('search');
+    setFocus('search');
+  };
+
+  const onSubmit: SubmitHandler<SearchBarValues> = async () => {
+    if (!searchValue?.trim()) return;
+
+    const { data } = await refetch();
+
+    if (onSearchResult) {
+      onSearchResult(data ?? null);
+    }
+  };
+
+  return (
+    <SearchForm onSubmit={handleSubmit(onSubmit)}>
+      <SearchButton>
+        <SearchIcon />
+      </SearchButton>
+      <HookFormInput
+        name="search"
+        register={register}
+        placeholder="맛집 후기 또는 사용자 검색"
+        css={css`
+          width: 100%;
+          height: 5rem;
+          border: 1px solid #ddd;
+          border-radius: 1.4rem;
+          padding: 1rem 3rem 1rem;
+        `}
+      />
+      <SearchCloseButton>
+        {searchValue && (
+          <CloseFilledIcon
+            onClick={handleResetValue}
+            css={css`
+              width: 2rem;
+              height: 2rem;
+              z-index: 10;
+              transform: translateY(-0.1rem);
+            `}
+          />
+        )}
+      </SearchCloseButton>
+    </SearchForm>
+  );
+}

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -69,27 +69,31 @@ export default function SearchBar({ onSearchResult }: SearchBarProps) {
         name="search"
         register={register}
         placeholder="맛집 후기 또는 사용자 검색"
-        css={css`
-          width: 100%;
-          height: 5rem;
-          border: 1px solid #ddd;
-          border-radius: 1.4rem;
-          padding: 1rem 3rem 1rem;
-        `}
+        css={inputStyle}
       />
       <SearchCloseButton>
         {searchValue && (
           <CloseFilledIcon
             onClick={handleResetValue}
-            css={css`
-              width: 2rem;
-              height: 2rem;
-              z-index: 10;
-              transform: translateY(-0.1rem);
-            `}
+            css={closeFilledIconStyle}
           />
         )}
       </SearchCloseButton>
     </SearchForm>
   );
 }
+
+const inputStyle = css`
+  width: 100%;
+  height: 5rem;
+  border: 1px solid #ddd;
+  border-radius: 1.4rem;
+  padding: 1rem 3rem 1rem;
+`;
+
+const closeFilledIconStyle = css`
+  width: 2rem;
+  height: 2rem;
+  z-index: 10;
+  transform: translateY(-0.1rem);
+`;

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -1,5 +1,7 @@
 import { css } from '@emotion/react';
+import { useEffect } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useSearchAll } from '@/hooks/useSearch';
 import { SearchResultType } from '@/types/response';
@@ -21,13 +23,19 @@ export default function SearchBar({ onSearchResult }: SearchBarProps) {
   const { register, handleSubmit, watch, setFocus, resetField, setValue } =
     useForm<SearchBarValues>();
 
+  const navigate = useNavigate();
+
   const searchValue = watch('search');
 
   const { refetch } = useSearchAll(searchValue);
 
+  const [searchParams] = useSearchParams();
+  const searchQuery = searchParams.get('q');
+
   const handleResetValue = () => {
     resetField('search');
     setFocus('search');
+    navigate({ pathname: '/search' });
   };
 
   const onSubmit: SubmitHandler<SearchBarValues> = async () => {
@@ -39,6 +47,18 @@ export default function SearchBar({ onSearchResult }: SearchBarProps) {
       onSearchResult(data ?? null);
     }
   };
+
+  useEffect(() => {
+    if (searchValue != null) {
+      navigate({ pathname: '/search', search: `?q=${searchValue}` });
+    }
+  }, [searchValue]);
+
+  useEffect(() => {
+    if (searchQuery != null) {
+      setValue('search', searchQuery);
+    }
+  }, [searchQuery]);
 
   return (
     <SearchForm onSubmit={handleSubmit(onSubmit)}>

--- a/src/components/SearchBar/style.ts
+++ b/src/components/SearchBar/style.ts
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+
+export const SearchForm = styled.form`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  position: relative;
+  padding: 0 2rem;
+`;
+
+export const SearchButton = styled.button`
+  position: absolute;
+  left: 2.7rem;
+  width: 2rem;
+  height: 2rem;
+  z-index: 10;
+`;
+
+export const SearchCloseButton = styled.button`
+  display: flex;
+  gap: 0.5rem;
+  position: absolute;
+  right: 2.8rem;
+`;

--- a/src/components/SearchBar/style.ts
+++ b/src/components/SearchBar/style.ts
@@ -10,7 +10,9 @@ export const SearchForm = styled.form`
 
 export const SearchButton = styled.button`
   position: absolute;
+  top: 50%;
   left: 2.7rem;
+  transform: translateY(-50%);
   width: 2rem;
   height: 2rem;
   z-index: 10;
@@ -20,5 +22,7 @@ export const SearchCloseButton = styled.button`
   display: flex;
   gap: 0.5rem;
   position: absolute;
+  top: 50%;
   right: 2.8rem;
+  transform: translateY(-50%);
 `;

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { searchAll } from '@/services/Search/search';
+
+const searchKeys = {
+  all: (query: string) => ['searchAll', query] as const,
+};
+
+export const useSearchAll = (query: string) => {
+  return useQuery({
+    queryKey: searchKeys.all(query),
+    queryFn: () => searchAll(query),
+    enabled: false,
+  });
+};

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,3 +1,18 @@
+import { useState } from 'react';
+
+import SearchBar from '@/components/SearchBar';
+import { SearchResultType } from '@/types/response';
+
 export default function SearchPage() {
-  return <div>SearchPage</div>;
+  const [searchResult, setSearchResult] = useState<SearchResultType>(null);
+
+  const handleSearchResult = (result: SearchResultType) => {
+    setSearchResult(result);
+  };
+
+  return (
+    <div>
+      <SearchBar onSearchResult={handleSearchResult} />
+    </div>
+  );
 }

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -11,8 +11,8 @@ export default function SearchPage() {
   };
 
   return (
-    <div>
+    <>
       <SearchBar onSearchResult={handleSearchResult} />
-    </div>
+    </>
   );
 }

--- a/src/services/Channel/channel.ts
+++ b/src/services/Channel/channel.ts
@@ -1,5 +1,5 @@
-import { Channel } from '@/types';
 import { CreateChannelPayload } from '@/types/payload';
+import { Channel } from '@/types/response';
 
 import { axiosAuthInstance, axiosInstance } from '../axiosInstance';
 import { ENDPOINT } from '../endPoint';

--- a/src/services/Post/comment.ts
+++ b/src/services/Post/comment.ts
@@ -1,5 +1,5 @@
-import { Comment } from '@/types';
 import { CreateCommentPayload } from '@/types/payload';
+import { Comment } from '@/types/response';
 
 import { axiosAuthInstance } from '../axiosInstance';
 import { ENDPOINT } from '../endPoint';

--- a/src/services/Post/like.ts
+++ b/src/services/Post/like.ts
@@ -1,7 +1,7 @@
-import { Like } from '@/types';
+import { Like } from '@/types/response';
 
-import { axiosAuthInstance } from './axiosInstance';
-import { ENDPOINT } from './endPoint';
+import { axiosAuthInstance } from '../axiosInstance';
+import { ENDPOINT } from '../endPoint';
 
 /**
  * @description 특정 포스트에 좋아요를 눌렀을 때 호출합니다.

--- a/src/services/Post/post.ts
+++ b/src/services/Post/post.ts
@@ -1,10 +1,10 @@
-import { Post } from '@/types';
 import {
   CreatePostPayload,
   GetPostByChannelPayload,
   GetPostByUserPayload,
   UpdatePostPayload,
 } from '@/types/payload';
+import { Post } from '@/types/response';
 
 import { axiosInstance } from '../axiosInstance';
 import { ENDPOINT } from '../endPoint';

--- a/src/services/Search/search.ts
+++ b/src/services/Search/search.ts
@@ -1,4 +1,4 @@
-import { Post, User } from '@/types';
+import { Post, User } from '@/types/response';
 
 import { axiosInstance } from '../axiosInstance';
 import { ENDPOINT } from '../endPoint';
@@ -8,6 +8,8 @@ export const searchUsers = async (query: string) => {
     const response = await axiosInstance.get<User[]>(
       ENDPOINT.SEARCH.USERS(query),
     );
+
+    console.log(response);
 
     return response;
   } catch (error) {

--- a/src/services/User/notification.ts
+++ b/src/services/User/notification.ts
@@ -1,5 +1,5 @@
-import { Notification } from '@/types';
 import { SendNotificationsPayload } from '@/types/payload';
+import { Notification } from '@/types/response';
 
 import { axiosAuthInstance } from '../axiosInstance';
 import { ENDPOINT } from '../endPoint';

--- a/src/services/User/setting.ts
+++ b/src/services/User/setting.ts
@@ -1,5 +1,5 @@
-import { User } from '@/types';
 import { UpdateUserNamePayload } from '@/types/payload';
+import { User } from '@/types/response';
 
 import { axiosAuthInstance } from '../axiosInstance';
 import { ENDPOINT } from '../endPoint';

--- a/src/services/User/user.ts
+++ b/src/services/User/user.ts
@@ -1,10 +1,13 @@
-import { User } from '@/types';
 import { GetUsersPayload, UpdateProfileImagePayload } from '@/types/payload';
+import { User } from '@/types/response';
 
 import { axiosInstance } from '../axiosInstance';
 import { ENDPOINT } from '../endPoint';
 
-export const getUsers = async ({ offset = 0, limit = 10 }: GetUsersPayload) => {
+export const getUsers = async ({
+  offset = 0,
+  limit = 10,
+}: GetUsersPayload = {}) => {
   try {
     const response = await axiosInstance.get<User[]>(ENDPOINT.USERS.GET_USERS, {
       params: {

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -95,3 +95,5 @@ export interface Message {
   createdAt: string;
   updatedAt: string;
 }
+
+export type SearchResultType = User[] | Post[] | null;


### PR DESCRIPTION
## 🌱 만들고자 하는 기능
검색 페이지에서 사용되는 검색창을 구현하고 API를 연동합니다.

## 🌱 구현 내용

### SearchBar
- **`유저 및 포스트를 검색`** 할 수 있는 SearchBar 구현
- 검색 API query hook 연동
- **`상위 컴포넌트에서`** SearchBar의 **`searchResult 결과를 받을 수 있게`** 구현
- 검색어에 맞춰서 **`url params 변경`** (localhost:3000/search?**q=검색어**)
  - 새로고침 시 params 값에 맞춰서 검색창 input 값을 초기화합니다. 

### 기타 수정 사항
- type의 import 경로 수정
- HookFormInput의 css를 rem단위로 변경하고 width를 100%로 변경

## ✅ 나누고 싶은 점

- searchResult를 콜백 함수로 상위 컴포넌트에 전달해주고 있습니다.
- **혹시 query Key를 이용해서 queryClient로 데이터를 가져올 수 있는 방법이나 더 좋은 방법이 있을까요..?!**
- HookFormInput의 width를 100%로 변경해두었습니다.
- type 경로가 잘못된 경우가 있어서 경로에 맞춰서 수정해두었습니다!
- 다양한 피드백 환영입니다~!!