### PR TITLE
[✨feat]: 프로필 자기 소개 api연동 

### DIFF
--- a/src/hooks/useGetProfile.ts
+++ b/src/hooks/useGetProfile.ts
@@ -1,8 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { getPostByUser, getPostDetail } from '@/services/Post/post';
+import { updateUserName } from '@/services/User/setting';
 import { updateProfileImage } from '@/services/User/user';
 import { getUser } from '@/services/User/user';
+import { UpdateUserNamePayload } from '@/types/payload';
 
 export const useGetPost = (userId: string) => {
   return useQuery({
@@ -20,7 +22,6 @@ export const useChangeImage = (
     onSuccess: async () => {
       // 이미지 변경 후 추가로직을 여기에 작성
       // 예: 프로필 정보를 다시 불러오는 등의 작업
-      console.log('이미지 바뀜');
       await queryClient.refetchQueries(['checkAuthUser']);
       setIsLoading(false); // 로딩 완료 시 isLoading 상태를 false로 설정
     },
@@ -51,4 +52,26 @@ export const useGetUser = (userId: string) => {
     queryKey: ['getUserInfo', userId],
     queryFn: () => getUser(userId),
   });
+};
+
+export const useChangeIntroduce = () => {
+  const queryClient = useQueryClient();
+  const { mutate, data } = useMutation(updateUserName, {
+    onSuccess: async () => {
+      await queryClient.refetchQueries(['checkAuthUser']);
+    },
+  });
+
+  const changeIntroduce = async ({
+    fullName,
+    username,
+  }: UpdateUserNamePayload) => {
+    try {
+      mutate({ fullName, username });
+    } catch (error) {
+      console.error('자기소개 전송 오류', error);
+    }
+  };
+
+  return { changeIntroduce, data };
 };

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -13,6 +13,7 @@ import {
   PLACEHOLDER_DEFAULTS,
 } from '@/constants/profile';
 import { useCheckAuthUser } from '@/hooks/useAuth';
+import { useChangeIntroduce } from '@/hooks/useGetProfile';
 import { useChangeImage } from '@/hooks/useGetProfile';
 
 import {
@@ -33,6 +34,13 @@ export default function ProfilePage() {
   const params = useParams();
   const userId = params.userId;
   const navigate = useNavigate();
+  const { changeIntroduce } = useChangeIntroduce();
+
+  useEffect(() => {
+    if (authUser) {
+      setIntroduction(authUser.username || '');
+    }
+  }, [authUser]);
 
   useEffect(() => {
     if (userId === 'undefined') {
@@ -54,6 +62,10 @@ export default function ProfilePage() {
   const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setIsEditing((prevIsEditing) => !prevIsEditing);
+
+    if (authUser) {
+      changeIntroduce({ fullName: authUser.fullName, username: introduction });
+    }
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -61,6 +73,14 @@ export default function ProfilePage() {
       setIntroduction(e.target.value);
     } else {
       alert('작성 범위를 초과했습니다.');
+
+      if (authUser) {
+        // 범위를 넘기면 alert 발생하면서 초기값으로 돌아가게 되어서 일단은 서버쪽에 보내는 쪽으로 저장하도록했습니다.
+        changeIntroduce({
+          fullName: authUser.fullName,
+          username: introduction,
+        });
+      }
     }
   };
 

--- a/src/services/User/setting.ts
+++ b/src/services/User/setting.ts
@@ -6,14 +6,14 @@ import { ENDPOINT } from '../endPoint';
 
 export const updateUserName = async ({
   fullName,
-  userName,
+  username,
 }: UpdateUserNamePayload) => {
   try {
     const response = await axiosAuthInstance.put<User>(
       ENDPOINT.SETTINGS.UPDATE_USER,
       {
         fullName,
-        userName,
+        username,
       },
     );
 

--- a/src/types/payload.ts
+++ b/src/types/payload.ts
@@ -51,7 +51,7 @@ export type CreatePostPayload = Omit<UpdatePostPayload, 'postId'>;
 
 export interface UpdateUserNamePayload {
   fullName: string;
-  userName: string;
+  username?: string;
 }
 
 export interface GetUsersPayload extends Pagination {}

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,10 +1,10 @@
 export interface PropsIntroductionEditor {
   isEditing: boolean;
-  introduction: string;
+  introduction?: string;
   onEditButtonClick: () => void;
   onFormSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   onInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  placeholderText: string;
+  placeholderText?: string;
   buttonText: string;
 }
 

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -6,6 +6,7 @@ export interface UserReponse {
 export interface User {
   _id: string;
   fullName: string;
+  username?: string;
   email: string;
   posts: Post[];
   likes: Like[];


### PR DESCRIPTION
## 🌱 만들고자 하는 기능
프로필 페이지에서 자기소개

## 🌱 구현 내용
- 자기소개 부분을 `username`으로 받아와 처리하였습니다.
- 값이 없을 때도 처리 가능하게 구현하였습니다.
- 글자 범위가 초과하였을 때도 `alert` 뜨더라도 input 값을 유지시켰습니다.

## 🌱 나누고 싶은 이야기
`alert` 뜨더라도 input 값을 유지할 수 있게 일단은 서버에 데이터를 보내는 쪽으로 하였는데 비효율적이라고 느껴져서
혹시 더 좋은 방법이 있을까요? 


