### PR TITLE
[✨feat]: 프로필에서 로그아웃 구현

### DIFF
--- a/src/components/Common/Avatar/index.tsx
+++ b/src/components/Common/Avatar/index.tsx
@@ -21,7 +21,7 @@ export default function Avatar({
   const [loaded, setLoaded] = useState<boolean>(false);
   const [hasError, setHasError] = useState<boolean>(false);
 
-  const defaultAvatar = `../../../${DEFAULT_PROFILE_IMAGE}`;
+  const defaultAvatar = DEFAULT_PROFILE_IMAGE;
 
   useEffect(() => {
     const image = new Image();

--- a/src/components/Common/Button/Button.tsx
+++ b/src/components/Common/Button/Button.tsx
@@ -2,7 +2,7 @@ import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 import React from 'react';
 
-interface ButtonProps {
+interface ButtonProps extends React.ComponentProps<'button'> {
   width?: string;
   height?: string;
   borderRadius?: string;

--- a/src/components/PostUserProfile/index.tsx
+++ b/src/components/PostUserProfile/index.tsx
@@ -49,7 +49,7 @@ export default function PostUserProfile() {
           <UserWrapper>
             <Label>자기소개</Label>
             <IntroductionWrapper>
-              <Introduction>만나서 반갑습니다.</Introduction>
+              <Introduction>{user.username}</Introduction>
               <IntroductionBar />
             </IntroductionWrapper>
             <SelectorWrapper>

--- a/src/components/PostUserProfile/style.ts
+++ b/src/components/PostUserProfile/style.ts
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import { PROFILE_BACKGROUND_IMAGE } from '@/constants/profile';
 import { theme } from '@/styles/Theme';
 
 export const ProfileWrapper = styled.div`
@@ -7,7 +8,7 @@ export const ProfileWrapper = styled.div`
 `;
 
 export const ProfileBackGroundImage = styled.div`
-  background-image: url('../../../public/images/profileBackground.png');
+  background-image: url(${PROFILE_BACKGROUND_IMAGE});
   background-size: cover;
   font-weight: ${theme.fontWeight.medium};
 `;

--- a/src/components/PostUserProfile/style.ts
+++ b/src/components/PostUserProfile/style.ts
@@ -15,7 +15,7 @@ export const ProfileBackGroundImage = styled.div`
 
 export const UserInfoWrapper = styled.div`
   display: flex;
-  padding-top: 16rem;
+  padding-top: 14rem;
   width: 100%;
 `;
 
@@ -28,7 +28,7 @@ export const UserWrapper = styled.div`
 
 export const ImageWrapper = styled.div`
   margin-top: 1.2rem;
-  margin-left: 4rem;
+  margin-left: 2rem;
 `;
 
 export const Label = styled.span`

--- a/src/components/UserIntroductionEditor/index.tsx
+++ b/src/components/UserIntroductionEditor/index.tsx
@@ -4,6 +4,7 @@ import { PropsIntroductionEditor } from '@/types/profile';
 
 import HookFormInput from '../Common/HookFormInput';
 import {
+  EmptyIntroduce,
   Introduction,
   IntroductionBar,
   IntroductionButton,
@@ -45,7 +46,13 @@ export default function UserIntroductionEditor({
       ) : (
         <>
           <IntroductionWrapper>
-            <Introduction>{introduction}</Introduction>
+            <Introduction>
+              {introduction === '' ? (
+                <EmptyIntroduce>자기소개를 작성하세요.</EmptyIntroduce>
+              ) : (
+                introduction
+              )}
+            </Introduction>
             <IntroductionButton onClick={onEditButtonClick}>
               {buttonText}
             </IntroductionButton>

--- a/src/components/UserIntroductionEditor/style.ts
+++ b/src/components/UserIntroductionEditor/style.ts
@@ -2,8 +2,12 @@ import styled from '@emotion/styled';
 
 import { theme } from '@/styles/Theme';
 
+export const EmptyIntroduce = styled.div`
+  color: #ccc;
+`;
+
 export const Introduction = styled.span`
-  margin-top: 0.85rem;
+  margin-top: 0.83rem;
   margin-left: 0.4rem;
   box-sizing: border-box;
 `;

--- a/src/constants/profile.ts
+++ b/src/constants/profile.ts
@@ -5,4 +5,5 @@ export const PLACEHOLDER_DEFAULTS = '자기소개를 작성하세요.';
 export const DEFAULT_HEIGHT = 24;
 export const LEFT_BUTTON_TEXT = '내가 작성한 글 목록';
 export const RIGHT_BUTTON_TEXT = ' 좋아요 목록';
-export const DEFAULT_PROFILE_IMAGE = '/public/images/defaultProfileImage.png';
+export const DEFAULT_PROFILE_IMAGE = '/images/defaultProfileImage.png';
+export const PROFILE_BACKGROUND_IMAGE = '/images/profileBackground.png';

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 
+import Button from '@/components/Common/Button/Button';
 import ImageUpload from '@/components/Common/ImageUpload';
 import PostSelector from '@/components/PostSelector';
 import PostUserProfile from '@/components/PostUserProfile';
@@ -15,9 +16,11 @@ import {
   PLACEHOLDER_DEFAULTS,
 } from '@/constants/profile';
 import { useCheckAuthUser } from '@/hooks/useAuth';
+import { useSignOut } from '@/hooks/useAuth';
 import { useChangeIntroduce } from '@/hooks/useGetProfile';
 import { useChangeImage } from '@/hooks/useGetProfile';
 import { selectedFileAtom } from '@/recoil/selectedFile';
+import { theme } from '@/styles/Theme';
 
 import {
   ImageWrapper,
@@ -39,6 +42,8 @@ export default function ProfilePage() {
   const userId = params.userId;
   const navigate = useNavigate();
   const { changeIntroduce } = useChangeIntroduce();
+
+  const { mutate: signOut } = useSignOut();
 
   useEffect(() => {
     if (authUser) {
@@ -69,6 +74,14 @@ export default function ProfilePage() {
 
     if (authUser) {
       changeIntroduce({ fullName: authUser.fullName, username: introduction });
+    }
+  };
+
+  const handleLogOutButtonClick = () => {
+    const confirm = window.confirm('로그아웃 하시겠습니까?');
+    if (confirm) {
+      signOut();
+      navigate('/');
     }
   };
 
@@ -127,6 +140,16 @@ export default function ProfilePage() {
                   userName={authUser.fullName}
                   userId={authUser.email}
                 />
+                <Button
+                  onClick={handleLogOutButtonClick}
+                  style={{ marginLeft: '2rem', marginTop: '4rem' }}
+                  width="60px"
+                  backgroundColor={theme.colors.lightGray}
+                  height="35px"
+                  textColor={theme.colors.gray}
+                  borderRadius="19px">
+                  로그아웃
+                </Button>
               </UserInfoWrapper>
             </ProfileBackGroundImage>
             <UserWrapper>

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -8,6 +8,7 @@ import PostUserProfile from '@/components/PostUserProfile';
 import Skeleton from '@/components/Skeleton';
 import UserInfo from '@/components/UserInfo';
 import UserIntroductionEditor from '@/components/UserIntroductionEditor';
+import { DEFAULT_PROFILE_IMAGE } from '@/constants/profile';
 import {
   DONE_BUTTON_TEXT,
   EDIT_BUTTON_TEXT,
@@ -92,7 +93,8 @@ export default function ProfilePage() {
 
   const buttonText = isEditing ? DONE_BUTTON_TEXT : EDIT_BUTTON_TEXT;
 
-  const defaultImage = '../../../public/images/defaultProfileImage.png';
+  const defaultImage = DEFAULT_PROFILE_IMAGE;
+
   return (
     <>
       <>

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -142,7 +142,7 @@ export default function ProfilePage() {
                 />
                 <Button
                   onClick={handleLogOutButtonClick}
-                  style={{ marginLeft: '2rem', marginTop: '4rem' }}
+                  style={{ marginLeft: '1rem', marginTop: '4rem' }}
                   width="60px"
                   backgroundColor={theme.colors.lightGray}
                   height="35px"

--- a/src/pages/ProfilePage/style.ts
+++ b/src/pages/ProfilePage/style.ts
@@ -18,7 +18,7 @@ export const ProfileBackGroundImage = styled.div`
 
 export const UserInfoWrapper = styled.div`
   display: flex;
-  padding-top: 16rem;
+  padding-top: 14rem;
   width: 100%;
 `;
 
@@ -30,7 +30,7 @@ export const UserWrapper = styled.div`
 
 export const ImageWrapper = styled.div`
   margin-top: 1.2rem;
-  margin-left: 4rem;
+  margin-left: 2rem;
 `;
 
 export const Label = styled.span`

--- a/src/pages/ProfilePage/style.ts
+++ b/src/pages/ProfilePage/style.ts
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import { PROFILE_BACKGROUND_IMAGE } from '@/constants/profile';
 import { theme } from '@/styles/Theme';
 
 export const ProfileWrapper = styled.div`
@@ -7,7 +8,7 @@ export const ProfileWrapper = styled.div`
 `;
 
 export const ProfileBackGroundImage = styled.div`
-  background-image: url('../../../public/images/profileBackground.png');
+  background-image: url(${PROFILE_BACKGROUND_IMAGE});
   background-size: cover;
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

프로필 페이지에 로그아웃  구현

## 🌱 구현 내용
- 로그아웃 버튼 클릭 시 로그아웃이 됩니다.
-  `Button` 컴포넌트를 사용했습니다.
-  프로필 기본이미지랑 배경이미지 절대경로로 수정하였습니다.
- 자기소개가 빈 값일 때 `placeholder`를 주었습니다.
<img width="409" alt="스크린샷 2024-01-16 오후 7 07 23" src="https://github.com/prgrms-fe-devcourse/FEDC5_MatNam_Ducki/assets/81172451/4c68a7fb-3c7a-4dc9-9518-f4c2e03ede72">

