### PR TITLE
[✨feat]: 대화 목록 리스트에 메세지, 마지막으로 보낸 시간 추가

### DIFF
--- a/src/components/DirectMessage/UserProfileInfo/index.tsx
+++ b/src/components/DirectMessage/UserProfileInfo/index.tsx
@@ -1,7 +1,11 @@
 import { DEFAULT_PROFILE_IMAGE } from '@/constants/profile';
 import { User } from '@/types/response';
+import { getElapsedTime } from '@/utils/getElapsedTime';
 
 import {
+  LastSendDateText,
+  Message,
+  UserInfo,
   UserInfoWrapper,
   UserName,
   UserOnlineIcon,
@@ -12,18 +16,28 @@ import {
 
 interface UserProfileInfoProps {
   user: User;
+  message: string;
+  lastSendDate: string;
 }
 
-export default function UserProfileInfo({ user }: UserProfileInfoProps) {
+export default function UserProfileInfo({
+  user,
+  message,
+  lastSendDate,
+}: UserProfileInfoProps) {
   return (
     <UserInfoWrapper>
-      <UserProfileWrapper>
-        <UserProfileImage src={user.image ?? DEFAULT_PROFILE_IMAGE} />
-        <UserOnlineIconWrapper>
-          <UserOnlineIcon active={user.isOnline.toString()} />
-        </UserOnlineIconWrapper>
-      </UserProfileWrapper>
-      <UserName>{user.fullName}</UserName>
+      <UserInfo>
+        <UserProfileWrapper>
+          <UserProfileImage src={user.image ?? DEFAULT_PROFILE_IMAGE} />
+          <UserOnlineIconWrapper>
+            <UserOnlineIcon active={user.isOnline.toString()} />
+          </UserOnlineIconWrapper>
+        </UserProfileWrapper>
+        <UserName>{user.fullName}</UserName>
+        <Message>{message}</Message>
+      </UserInfo>
+      <LastSendDateText>{getElapsedTime(lastSendDate)}</LastSendDateText>
     </UserInfoWrapper>
   );
 }

--- a/src/components/DirectMessage/UserProfileInfo/style.ts
+++ b/src/components/DirectMessage/UserProfileInfo/style.ts
@@ -18,12 +18,19 @@ export const UserItemWrapper = styled.li`
 
 export const UserInfoWrapper = styled.div`
   display: flex;
-  gap: 1.5rem;
   align-items: center;
+  justify-content: space-between;
+`;
+
+export const UserInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 `;
 
 export const UserProfileWrapper = styled.div`
   position: relative;
+  flex-shrink: 0;
 `;
 
 export const UserProfileImage = styled.img`
@@ -37,6 +44,22 @@ export const UserProfileImage = styled.img`
 export const UserName = styled.span`
   position: relative;
   font-weight: ${theme.fontWeight.medium};
+  flex-shrink: 0;
+`;
+
+export const Message = styled.span`
+  color: ${theme.colors.gray};
+  width: 100%;
+  max-width: 16rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+`;
+
+export const LastSendDateText = styled.span`
+  color: ${theme.colors.gray};
 `;
 
 export const UserOnlineIconWrapper = styled.div`


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

대화 목록 아이템에서 마지막 메세지와 마지막으로 보낸 시간을 보여줍니다.

## 🌱 구현 내용

<img width="324" alt="스크린샷 2024-01-17 오전 11 49 32" src="https://github.com/prgrms-fe-devcourse/FEDC5_MatNam_Ducki/assets/55135881/451e4d5c-5546-47c2-9708-02332ba7a58b">


- 메세지, 마지막으로 보낸 시간 표시
- 최대 2줄 말줄임 적용

## ✅ 나누고 싶은 점

- 간단한 작업이라서 빠르게 머지해도 될 것 같습니다!
