### PR TITLE
[🐛fix]: SearchPost 데이터 parse 수정, 자기소개 필드 수정

### DIFF
--- a/src/components/PostUserProfile/index.tsx
+++ b/src/components/PostUserProfile/index.tsx
@@ -27,7 +27,6 @@ export default function PostUserProfile() {
   }
 
   const { data: user } = useGetUser(userId);
-  console.log(user?.username);
 
   return (
     <>

--- a/src/components/PostUserProfile/index.tsx
+++ b/src/components/PostUserProfile/index.tsx
@@ -26,6 +26,7 @@ export default function PostUserProfile() {
   }
 
   const { data: user } = useGetUser(userId);
+  console.log(user?.username);
 
   return (
     <>

--- a/src/components/PostUserProfile/index.tsx
+++ b/src/components/PostUserProfile/index.tsx
@@ -8,6 +8,7 @@ import UserPosts from '../UserPosts';
 import {
   Introduction,
   IntroductionBar,
+  IntroductionContainer,
   IntroductionWrapper,
   Label,
   PostsTitle,
@@ -49,11 +50,13 @@ export default function PostUserProfile() {
           <UserWrapper>
             {user.username && (
               <>
-                <Label>자기소개</Label>
-                <IntroductionWrapper>
-                  <Introduction>{user.username}</Introduction>
-                  <IntroductionBar />
-                </IntroductionWrapper>
+                <IntroductionContainer>
+                  <Label>자기소개</Label>
+                  <IntroductionWrapper>
+                    <Introduction>{user.username}</Introduction>
+                    <IntroductionBar />
+                  </IntroductionWrapper>
+                </IntroductionContainer>
               </>
             )}
             <PostWrapper>

--- a/src/components/PostUserProfile/style.ts
+++ b/src/components/PostUserProfile/style.ts
@@ -37,12 +37,18 @@ export const Label = styled.span`
   font-size: 1.3rem;
 `;
 
+export const IntroductionContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
 export const IntroductionWrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  gap: 1.5rem;
-  padding-bottom: 2rem;
+  gap: 0.5rem;
+  padding-bottom: 2.5rem;
 `;
 
 export const Introduction = styled.span`

--- a/src/components/UserIntroductionEditor/index.tsx
+++ b/src/components/UserIntroductionEditor/index.tsx
@@ -41,7 +41,6 @@ export default function UserIntroductionEditor({
               register={register}></HookFormInput>
             <IntroductionButton>{buttonText}</IntroductionButton>
           </IntroductionForm>
-          <IntroductionBar />
         </>
       ) : (
         <>
@@ -53,6 +52,7 @@ export default function UserIntroductionEditor({
                 introduction
               )}
             </Introduction>
+            <IntroductionBar />
             <IntroductionButton onClick={onEditButtonClick}>
               {buttonText}
             </IntroductionButton>

--- a/src/components/UserIntroductionEditor/style.ts
+++ b/src/components/UserIntroductionEditor/style.ts
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { theme } from '@/styles/Theme';
 
 export const EmptyIntroduce = styled.div`
-  color: #ccc;
+  color: ${theme.colors.gray};
 `;
 
 export const Introduction = styled.span`

--- a/src/pages/ReviewDetailPage/index.tsx
+++ b/src/pages/ReviewDetailPage/index.tsx
@@ -102,7 +102,7 @@ export default function ReviewDetail() {
                   <ThumbsDownIcon />
                 )}
               </ReviewHeaderLeft>
-              {user?.posts.some((post) => post._id === postId) && (
+              {user?.posts?.some((post) => post._id === postId) && (
                 <DropDownContainer items={dropDownItems} />
               )}
             </ReviewHeaderTitleWrapper>

--- a/src/pages/SearchPostPage/index.tsx
+++ b/src/pages/SearchPostPage/index.tsx
@@ -20,8 +20,6 @@ export default function SearchPostPage() {
 
   const postResult = data?.postData ?? [];
 
-  console.log(data);
-
   useEffect(() => {
     if (searchKeyword) {
       refetch();

--- a/src/pages/SearchPostPage/index.tsx
+++ b/src/pages/SearchPostPage/index.tsx
@@ -20,6 +20,8 @@ export default function SearchPostPage() {
 
   const postResult = data?.postData ?? [];
 
+  console.log(data);
+
   useEffect(() => {
     if (searchKeyword) {
       refetch();

--- a/src/services/Post/post.ts
+++ b/src/services/Post/post.ts
@@ -107,10 +107,6 @@ export const createPost = async ({
     formData.append('title', customPost);
     formData.append('channelId', channelId);
 
-    if (image) {
-      formData.append('image', image);
-    }
-
     await axiosAuthInstance.post(ENDPOINT.POSTS.CREATE, formData);
   } catch (error) {
     console.error(error);

--- a/src/services/Search/search.ts
+++ b/src/services/Search/search.ts
@@ -32,6 +32,15 @@ export const searchAll = async (query: string) => {
         if ('fullName' in item) {
           userData.push(item as User);
         } else {
+          if (item.title) {
+            const { review, restaurant, location, openingTime } = JSON.parse(
+              item.title,
+            );
+            item.review = review;
+            item.restaurant = restaurant;
+            item.location = location;
+            item.openingTime = openingTime;
+          }
           postData.push(item as Post);
         }
       });


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

- Search한 post 데이터 수정
- 자기소개 필드 수정
## 🌱 구현 내용

- Search한 post의 title 데이터를  `review`, `location`, `restaurant`, `openingTime`으로 parse하였습니다.
- 자기소개 필드에 밑줄이 생겼었는데 없애주었습니다
- `UserProfile`에서 자기소개 필드 이상했던 부분 수정해 주었습니다.

## 🌱 나누고 싶은점
- 다른 에러 더 발생하면 말씀해 주세요

