### PR TITLE
[🐛fix]: 로그인시 프로필 페이지 버그 수정

### DIFF
--- a/src/components/LikePosts/index.tsx
+++ b/src/components/LikePosts/index.tsx
@@ -16,7 +16,7 @@ export default function LikePosts() {
     return null;
   }
 
-  const likes = user.likes.map((item) => item.post); // 사용자의 좋아요한 게시물의 postId
+  const likes = user.likes.map((item) => item.post).reverse();
 
   const detailPosts = likes.map((item) => useGetPostDetail(item).data); // 게시물의 detailPost
 

--- a/src/components/LikePosts/index.tsx
+++ b/src/components/LikePosts/index.tsx
@@ -1,7 +1,8 @@
 import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 
-import { useCheckAuthUser } from '@/hooks/useAuth';
 import { useGetPostDetail } from '@/hooks/useGetProfile';
+import { userAtom } from '@/recoil/user';
 import { PATH } from '@/routes/path';
 
 import { ReviewCard } from '../ReviewCard/ReviewCard';
@@ -9,14 +10,13 @@ import { EmptyResultText, EmptyResultWrapper, PostWrapper } from './style';
 
 export default function LikePosts() {
   const navigate = useNavigate();
-  const { data: auth } = useCheckAuthUser();
+  const user = useRecoilValue(userAtom);
 
-  if (!auth) {
-    // auth가 undefined일 아무것도 렌더링하지 않음
+  if (!user) {
     return null;
   }
 
-  const likes = auth.likes.map((item) => item.post); // 사용자의 좋아요한 게시물의 postId
+  const likes = user.likes.map((item) => item.post); // 사용자의 좋아요한 게시물의 postId
 
   const detailPosts = likes.map((item) => useGetPostDetail(item).data); // 게시물의 detailPost
 

--- a/src/components/MyPosts/index.tsx
+++ b/src/components/MyPosts/index.tsx
@@ -1,7 +1,8 @@
 import { useNavigate } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 
-import { useCheckAuthUser } from '@/hooks/useAuth';
 import { useGetPost } from '@/hooks/useGetProfile';
+import { userAtom } from '@/recoil/user';
 import { PATH } from '@/routes/path';
 
 import { MyReview } from '../ReviewCard/MyReview';
@@ -9,17 +10,16 @@ import { EmptyResultText, EmptyResultWrapper, PostWrapper } from './style';
 
 export default function MyPosts() {
   const navigate = useNavigate();
-  const { data: auth } = useCheckAuthUser();
+  const user = useRecoilValue(userAtom);
 
-  if (!auth) {
+  if (!user) {
     return null;
   }
-
-  const { data: posts } = useGetPost(auth._id);
+  const { data: posts } = useGetPost(user._id);
 
   return (
     <PostWrapper>
-      {posts?.length !== 0 && auth ? (
+      {posts?.length !== 0 && user ? (
         <>
           {posts?.map((item) => (
             <MyReview
@@ -30,7 +30,7 @@ export default function MyPosts() {
               review={item.review}
               likes={item.likes.length}
               channelId={item.channel._id}
-              id={auth._id}
+              id={user._id}
               onClick={() => navigate(`${PATH.REVIEWDETAIL}/${item._id}`)}
             />
           ))}

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -38,32 +38,26 @@ export default function ProfilePage() {
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const [introduction, setIntroduction] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const setSelectedFile = useSetRecoilState(selectedFileAtom);
-  const { changeImage } = useChangeImage(setIsLoading, setSelectedFile);
 
+  const setSelectedFile = useSetRecoilState(selectedFileAtom);
+  const navigate = useNavigate();
   const params = useParams();
   const userId = params.userId;
-  const navigate = useNavigate();
-  const { changeIntroduce } = useChangeIntroduce();
-
   const user = useRecoilValue(userAtom);
-
   const setUserState = useSetRecoilState(userAtom);
+
+  const { changeImage } = useChangeImage(setIsLoading, setSelectedFile);
+
+  const { changeIntroduce } = useChangeIntroduce();
 
   const { mutate: signOut } = useSignOut({ setUserState });
 
   useEffect(() => {
-    if (user) {
-      setIntroduction(user.username || '');
-    }
-  }, [user]);
-
-  useEffect(() => {
-    if (userId === 'undefined') {
+    if (!user) {
       Toast.info('로그인 후 이용해 보세요!');
       navigate('/signIn');
     }
-  }, [userId]);
+  }, [user]);
 
   const handleFileChange = (file: File | null) => {
     if (file) {
@@ -99,7 +93,6 @@ export default function ProfilePage() {
       Toast.info('작성 범위를 초과했습니다.');
 
       if (user) {
-        // 범위를 넘기면 alert 발생하면서 초기값으로 돌아가게 되어서 일단은 서버쪽에 보내는 쪽으로 저장하도록했습니다.
         changeIntroduce({
           fullName: user.fullName,
           username: introduction,


### PR DESCRIPTION
## 🌱 구현 내용
로그인 시 최초 프로필 페이지에 진입했을 때 깜빡거리는 현상 및 렌더링 되지않는 문제를 해결하였습니다.
<img width="395" alt="스크린샷 2024-04-11 오후 9 55 14" src="https://github.com/prgrms-fe-devcourse/FEDC5_MatNam_Ducki/assets/81172451/df04da59-5cd3-4949-89b9-411e42c46fc2">

## 오류가 발생한 이유
- 기존의 유저정보를 fetch를 통해서 매번 유저 정보를 가져와 사용했었는데 여기서 문제점이 프로필 페이지 진입시 유저 정보가 불러와 사용하기 전에 화면이 렌더링되어서 오류가 발생하였습니다.

## 해결 방법
- 로그인 시 recoil을 이용해 localStorage에 저장되어있는 유저정보를 통해서 프로필 진입여부를 판단하였고 그 하위 컴포넌트에서도 사용되는 컴포넌트 또한 recoil을 이용한 유저정보로 코드를 수정하였습니다.
<img width="392" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC5_MatNam_Ducki/assets/81172451/25bdebb9-2a26-44e5-8b3c-74af04bd8f5c">


### etc..
내가 좋아요한 목록들을 최신순으로 변경하였습니다.