### PR TITLE
[✨feat]: 스크롤 유지 기능 구현

### DIFF
--- a/src/components/Common/KeepScrollContainer/index.tsx
+++ b/src/components/Common/KeepScrollContainer/index.tsx
@@ -29,7 +29,9 @@ export default function KeepScrollContainer({ children }: PropsWithChildren) {
     if (scrollRef.current === null) return;
 
     if (isKeepScrollPath) {
-      scrollRef.current.scrollTo(0, scrollState.y);
+      setTimeout(() => {
+        scrollRef.current?.scrollTo(scrollState.x, scrollState.y);
+      }, 0);
 
       scrollRef.current.addEventListener('scroll', handleScroll);
       return () => {

--- a/src/components/Common/KeepScrollContainer/index.tsx
+++ b/src/components/Common/KeepScrollContainer/index.tsx
@@ -17,9 +17,10 @@ export default function KeepScrollContainer({ children }: PropsWithChildren) {
 
   const handleScroll = useThrottle(() => {
     if (scrollRef.current === null) return;
+    if (!isKeepScrollPath) return;
 
     setScrollState({
-      x: 0,
+      ...scrollState,
       y: scrollRef.current.scrollTop,
     });
   });

--- a/src/components/Common/KeepScrollContainer/index.tsx
+++ b/src/components/Common/KeepScrollContainer/index.tsx
@@ -17,8 +17,8 @@ export default function KeepScrollContainer({ children }: PropsWithChildren) {
     pathname === PATH.ROOT || pathname.includes(PATH.DIRECTMESSAGEDETAIL);
 
   const handleScroll = useThrottle(() => {
-    if (scrollRef.current === null) return;
     if (!isKeepScrollPath) return;
+    if (scrollRef.current === null) return;
 
     setScrollState({
       ...scrollState,
@@ -28,18 +28,9 @@ export default function KeepScrollContainer({ children }: PropsWithChildren) {
 
   useEffect(() => {
     if (scrollRef.current === null) return;
-
-    if (isKeepScrollPath) {
-      setTimeout(() => {
-        scrollRef.current?.scrollTo(scrollState.x, scrollState.y);
-      }, 0);
-
-      scrollRef.current.addEventListener('scroll', handleScroll);
-      return () => {
-        scrollRef.current?.removeEventListener('scroll', handleScroll);
-      };
-    } else {
+    if (!isKeepScrollPath) {
       scrollRef.current.scrollTo(0, 0);
+      return;
     }
   }, [scrollRef, pathname]);
 

--- a/src/components/Common/KeepScrollContainer/index.tsx
+++ b/src/components/Common/KeepScrollContainer/index.tsx
@@ -22,7 +22,7 @@ export default function KeepScrollContainer({ children }: PropsWithChildren) {
 
     setScrollState({
       ...scrollState,
-      y: scrollRef.current.scrollTop,
+      [pathname]: scrollRef.current.scrollTop,
     });
   });
 
@@ -32,6 +32,16 @@ export default function KeepScrollContainer({ children }: PropsWithChildren) {
       scrollRef.current.scrollTo(0, 0);
       return;
     }
+
+    setTimeout(() => {
+      const scrollY = scrollState[pathname] ?? 0;
+      scrollRef.current?.scrollTo(0, scrollY);
+    }, 0);
+
+    scrollRef.current.addEventListener('scroll', handleScroll);
+    return () => {
+      scrollRef.current?.removeEventListener('scroll', handleScroll);
+    };
   }, [scrollRef, pathname]);
 
   return <ScrollWrapper ref={scrollRef}>{children}</ScrollWrapper>;

--- a/src/components/Common/KeepScrollContainer/index.tsx
+++ b/src/components/Common/KeepScrollContainer/index.tsx
@@ -1,0 +1,11 @@
+import { PropsWithChildren } from 'react';
+
+import { useKeepScroll } from '@/hooks/useKeepScroll';
+
+import { ScrollWrapper } from './style';
+
+export default function KeepScrollContainer({ children }: PropsWithChildren) {
+  const { scrollRef } = useKeepScroll();
+
+  return <ScrollWrapper ref={scrollRef}>{children}</ScrollWrapper>;
+}

--- a/src/components/Common/KeepScrollContainer/index.tsx
+++ b/src/components/Common/KeepScrollContainer/index.tsx
@@ -13,7 +13,8 @@ export default function KeepScrollContainer({ children }: PropsWithChildren) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const { pathname } = useLocation();
-  const isKeepScrollPath = pathname === PATH.ROOT;
+  const isKeepScrollPath =
+    pathname === PATH.ROOT || pathname.includes(PATH.DIRECTMESSAGEDETAIL);
 
   const handleScroll = useThrottle(() => {
     if (scrollRef.current === null) return;

--- a/src/components/Common/KeepScrollContainer/index.tsx
+++ b/src/components/Common/KeepScrollContainer/index.tsx
@@ -1,11 +1,43 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 
-import { useKeepScroll } from '@/hooks/useKeepScroll';
+import { useThrottle } from '@/hooks/useThrottle';
+import { scrollAtom } from '@/recoil/scroll';
+import { PATH } from '@/routes/path';
 
 import { ScrollWrapper } from './style';
 
 export default function KeepScrollContainer({ children }: PropsWithChildren) {
-  const { scrollRef } = useKeepScroll();
+  const [scrollState, setScrollState] = useRecoilState(scrollAtom);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const { pathname } = useLocation();
+  const isKeepScrollPath = pathname === PATH.ROOT;
+
+  const handleScroll = useThrottle(() => {
+    if (scrollRef.current === null) return;
+
+    setScrollState({
+      x: 0,
+      y: scrollRef.current.scrollTop,
+    });
+  });
+
+  useEffect(() => {
+    if (scrollRef.current === null) return;
+
+    if (isKeepScrollPath) {
+      scrollRef.current.scrollTo(0, scrollState.y);
+
+      scrollRef.current.addEventListener('scroll', handleScroll);
+      return () => {
+        scrollRef.current?.removeEventListener('scroll', handleScroll);
+      };
+    } else {
+      scrollRef.current.scrollTo(0, 0);
+    }
+  }, [scrollRef, pathname]);
 
   return <ScrollWrapper ref={scrollRef}>{children}</ScrollWrapper>;
 }

--- a/src/components/Common/KeepScrollContainer/style.ts
+++ b/src/components/Common/KeepScrollContainer/style.ts
@@ -1,0 +1,7 @@
+import styled from '@emotion/styled';
+
+export const ScrollWrapper = styled.div`
+  width: 100%;
+  height: calc(100% - 14rem);
+  overflow: auto;
+`;

--- a/src/components/DirectMessage/MessageList/index.tsx
+++ b/src/components/DirectMessage/MessageList/index.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 
+import { useThrottle } from '@/hooks/useThrottle';
+import { scrollAtom } from '@/recoil/scroll';
 import { Message } from '@/types/response';
 
 import MessageItem from '../MessageItem';
@@ -12,12 +16,33 @@ interface MessageListProps {
 
 export default function MessageList({ userId, messageList }: MessageListProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const { pathname } = useLocation();
+  const [scrollState, setScrollState] = useRecoilState(scrollAtom);
+  const handleScroll = useThrottle(() => {
+    if (scrollRef.current === null) return;
+
+    setScrollState({
+      ...scrollState,
+      [pathname]: scrollRef.current.scrollTop,
+    });
+  });
 
   useEffect(() => {
     if (scrollRef.current) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
   }, [messageList]);
+  useEffect(() => {
+    if (!scrollRef.current) return;
+
+    const scrollY = scrollState[pathname] ?? scrollRef.current.scrollHeight;
+    scrollRef.current.scrollTop = scrollY;
+
+    scrollRef.current.addEventListener('scroll', handleScroll);
+    return () => {
+      scrollRef.current?.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
 
   return (
     <MessageListWrapper ref={scrollRef}>

--- a/src/components/DirectMessage/MessageList/index.tsx
+++ b/src/components/DirectMessage/MessageList/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 
@@ -18,6 +18,9 @@ export default function MessageList({ userId, messageList }: MessageListProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const { pathname } = useLocation();
   const [scrollState, setScrollState] = useRecoilState(scrollAtom);
+
+  const prevMessageList = useMemo(() => messageList, []);
+
   const handleScroll = useThrottle(() => {
     if (scrollRef.current === null) return;
 
@@ -28,10 +31,13 @@ export default function MessageList({ userId, messageList }: MessageListProps) {
   });
 
   useEffect(() => {
-    if (scrollRef.current) {
+    if (!scrollRef.current) return;
+
+    if (prevMessageList.length !== messageList.length) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
-  }, [messageList]);
+  }, [messageList, prevMessageList]);
+
   useEffect(() => {
     if (!scrollRef.current) return;
 

--- a/src/hooks/usePost.ts
+++ b/src/hooks/usePost.ts
@@ -7,6 +7,7 @@ export const useGetPostByChannel = ({ channelId }: GetPostByChannelPayload) => {
   return useQuery({
     queryKey: ['postsByChannel', channelId],
     queryFn: () => getPostByChannel({ channelId }),
+    keepPreviousData: true,
     retry: false,
   });
 };

--- a/src/hooks/useThrottle.ts
+++ b/src/hooks/useThrottle.ts
@@ -1,0 +1,25 @@
+import { useRef } from 'react';
+
+export const useThrottle = (callback: () => void, delay?: number) => {
+  const isWaiting = useRef(false);
+
+  const timerId = useRef<ReturnType<typeof setTimeout>>();
+  const timeDelay = delay ?? 500;
+
+  return () => {
+    if (!isWaiting.current) {
+      callback();
+      isWaiting.current = true;
+
+      setTimeout(() => {
+        isWaiting.current = false;
+      }, timeDelay);
+    }
+
+    if (timerId.current) clearTimeout(timerId.current);
+
+    timerId.current = setTimeout(() => {
+      callback();
+    }, timeDelay);
+  };
+};

--- a/src/hooks/useThrottle.ts
+++ b/src/hooks/useThrottle.ts
@@ -4,7 +4,7 @@ export const useThrottle = (callback: () => void, delay?: number) => {
   const isWaiting = useRef(false);
 
   const timerId = useRef<ReturnType<typeof setTimeout>>();
-  const timeDelay = delay ?? 500;
+  const timeDelay = delay ?? 200;
 
   return () => {
     if (!isWaiting.current) {

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -5,6 +5,7 @@ import { useSetRecoilState } from 'recoil';
 
 import BottomNavBar from '@/components/BottomNavBar';
 import ErrorFallback from '@/components/Common/ErrorFallback';
+import KeepScrollContainer from '@/components/Common/KeepScrollContainer';
 import ModalContainer from '@/components/Common/Modal/ModalContainer';
 import Settings from '@/components/Common/Settings';
 import Spinner from '@/components/Common/Spinner';
@@ -13,7 +14,7 @@ import { ACCESS_TOKEN_KEY } from '@/constants/api';
 import { useCheckAuthUser } from '@/hooks/useAuth';
 import { userAtom } from '@/recoil/user';
 
-import { ContentWrapper, MainPageWrapper, ScrollWrapper } from './style';
+import { ContentWrapper, MainPageWrapper } from './style';
 
 export default function MainPage() {
   const token = localStorage.getItem(ACCESS_TOKEN_KEY);
@@ -34,11 +35,11 @@ export default function MainPage() {
       <ErrorBoundary FallbackComponent={ErrorFallback}>
         <Suspense fallback={<Spinner />}>
           <TitleHeader />
-          <ScrollWrapper>
+          <KeepScrollContainer>
             <ContentWrapper>
               <Outlet />
             </ContentWrapper>
-          </ScrollWrapper>
+          </KeepScrollContainer>
           <ModalContainer />
         </Suspense>
       </ErrorBoundary>

--- a/src/recoil/scroll.ts
+++ b/src/recoil/scroll.ts
@@ -1,0 +1,14 @@
+import { atom } from 'recoil';
+
+interface ScrollState {
+  x: number;
+  y: number;
+}
+
+export const scrollAtom = atom<ScrollState>({
+  key: 'scrollState',
+  default: {
+    x: 0,
+    y: 0,
+  },
+});

--- a/src/recoil/scroll.ts
+++ b/src/recoil/scroll.ts
@@ -1,7 +1,7 @@
 import { atom } from 'recoil';
 
 interface ScrollState {
-  [key: string]: number | null;
+  [pathname: string]: number | null;
 }
 
 export const scrollAtom = atom<ScrollState>({

--- a/src/recoil/scroll.ts
+++ b/src/recoil/scroll.ts
@@ -1,14 +1,10 @@
 import { atom } from 'recoil';
 
 interface ScrollState {
-  x: number;
-  y: number;
+  [key: string]: number | null;
 }
 
 export const scrollAtom = atom<ScrollState>({
   key: 'scrollState',
-  default: {
-    x: 0,
-    y: 0,
-  },
+  default: {},
 });


### PR DESCRIPTION
## 🌱 만들고자 하는 기능

리뷰 페이지, 메세지함의 **스크롤 위치를 유지**합니다.
스크롤 유지가 필요하지 않은 페이지인 경우 **스크롤을 최상단으로 설정**하였습니다.
scroll 이벤트에 **throttle을 적용하여 과도한 이벤트 발생을 방지**하였습니다.


## ✔️ Preview

### 리뷰 페이지

https://github.com/prgrms-fe-devcourse/FEDC5_MatNam_Ducki/assets/55135881/9f09fda7-27c2-4af0-8d2e-844deef347fb

### 메세지함

https://github.com/prgrms-fe-devcourse/FEDC5_MatNam_Ducki/assets/55135881/4656c620-5cc9-4f22-9153-307017cf41cd




## 🌱 구현 내용

- [x] path별 현재 스크롤 위치를 전역 상태로 관리
- [x] scroll 이벤트에 throttle을 이용하여 과도한 이벤트 발생 방지 
- [x] 스크롤 유지가 필요하지 않은 페이지인 경우 스크롤을 최상단으로 설정


## ✅ check list

리뷰 페이지만 스크롤을 유지하고 다른 페이지에서는 스크롤을 최상단으로 설정해두었습니다!
혹시 리뷰 페이지 외에도 스크롤 유지가 필요한 부분이 있을까요? -> _피드백 반영하여 메세지함도 고정하도록 수정했습니다!_
이 외에도 기능이나 코드 로직 등 질문이나 피드백 환영입니다!! 😃
