### PR TITLE
[🐛fix]: 비 로그인시 유저 프로필 문제 해결

### DIFF
--- a/src/components/ReviewCard/ReviewCard.tsx
+++ b/src/components/ReviewCard/ReviewCard.tsx
@@ -66,7 +66,7 @@ export const ReviewCard = ({
         <ProfileNickname
           onClick={(event) => {
             event.stopPropagation();
-            navigate(`${PATH.PROFILE}/${id}`);
+            navigate(`${PATH.USERPROFILE}/${id}`);
           }}>
           {profileName}
         </ProfileNickname>

--- a/src/components/UserInfo/index.tsx
+++ b/src/components/UserInfo/index.tsx
@@ -1,3 +1,6 @@
+import { useRecoilValue } from 'recoil';
+
+import { userAtom } from '@/recoil/user';
 import { PropsUserInfo } from '@/types/profile';
 
 import FollowButton from '../FollowButton';
@@ -9,11 +12,14 @@ export default function UserInfo({
   userId,
   followers,
 }: PropsUserInfo) {
+  const user = useRecoilValue(userAtom);
   return (
     <UserInfoSection>
       <UserName>{userName}</UserName>
       <UserId>{userEmail}</UserId>
-      <FollowButton userId={userId} followers={followers}></FollowButton>
+      {user && (
+        <FollowButton userId={userId} followers={followers}></FollowButton>
+      )}
     </UserInfoSection>
   );
 }

--- a/src/pages/ProfilePage/index.tsx
+++ b/src/pages/ProfilePage/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import AnimationContainer from '@/components/Common/AnimationContainer';
@@ -47,17 +47,17 @@ export default function ProfilePage() {
   const setUserState = useSetRecoilState(userAtom);
 
   const { changeImage } = useChangeImage(setIsLoading, setSelectedFile);
-
   const { changeIntroduce } = useChangeIntroduce();
-
   const { mutate: signOut } = useSignOut({ setUserState });
+  const { pathname } = useLocation();
+  const isUserProfile = pathname.includes('userprofile');
 
   useEffect(() => {
-    if (!user) {
+    if (!user && !isUserProfile) {
       Toast.info('로그인 후 이용해 보세요!');
       navigate('/signIn');
     }
-  }, [user]);
+  }, [user, isUserProfile]);
 
   const handleFileChange = (file: File | null) => {
     if (file) {


### PR DESCRIPTION
## 🌱 만들고자 하는 기능
비 로그인일 때  다른 유저 프로필 진입시 로그인 페이지로 다이렉트 되는 문제 해결
정상적인 동작은 비 로그인일 경우에도 다른 유저의 프로필 진입이 가능해야합니다.
## 🌱 구현 내용
- 저희가 path를  자신의 프로필 경로는 `PROFILE: /profile`, 유저 프로필 경로는 `USERPROFILE: /userprofile` 이렇게 설정해 놓았기에 ReviewCard 컴포넌트에서의 navigate 경로를 `USERPROFILE`로 수정하였습니다.
- `useLocation()`의 `pathname` 을 이용하여  url 경로에 userprofile 포함 유무에 따라 자신의 프로필인지 유저의 프로필인지 판단하여 비 로그인 시 유저 프로필 진입 문제를 해결했습니다.

## 🌱나누고 싶은 내용
- 비 로그인 시 유저 프로필에 있는 친구맺기를 일단 안보이게 UI를 변경하였는데... 비 로그인시에도 친구 맺기가 보이되 클릭시 로그인 페이지로 다이렉트 시켜주는 게 좋을까요? 아님 지금처럼 비 로그인 시에는 친구맺기를 안보이게 하는게 좋을까요?!
- 만약 전자 일 경우에는 송희님이 구현하신 팔로우 컴포넌트를 수정해야할거 같습니다! 
